### PR TITLE
Add CI pipeline and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: List changed files
+        id: changes
+        uses: tj-actions/changed-files@v44
+
+      - name: Determine docs-only
+        id: docs
+        run: |
+          docs_only=true
+          for f in ${{ steps.changes.outputs.all_changed_files }}; do
+            if [[ ! "$f" =~ \.md$ ]]; then
+              docs_only=false
+              break
+            fi
+          done
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install black flake8 pytest
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+
+      - name: Run markdownlint
+        run: npx markdownlint-cli '**/*.md'
+
+      - name: Run black
+        if: steps.docs.outputs.docs_only == 'false'
+        run: black --check .
+
+      - name: Run flake8
+        if: steps.docs.outputs.docs_only == 'false'
+        run: flake8 .
+
+      - name: Run pytest
+        if: steps.docs.outputs.docs_only == 'false'
+        run: pytest -v
+
+      - name: Check links
+        run: npx markdown-link-check README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,17 @@
 This file summarises **how to keep the repo healthy**.
 
 ## 1. CI policy
+
 | Rule | Why |
 |------|-----|
-| Every code‑touching commit **must** pass the full test‑suite and linters. | Prevents silent breakage |
-| Docs‑only commits run a fast markdown‑lint + link‑check job. | Saves CI minutes |
+| Every code commit **must** pass all tests and linters. | Prevents breakage |
+| Docs‑only commits run markdown‑lint + link‑check. | Saves CI minutes |
+
+The pipeline lives at `.github/workflows/ci.yml` and skips tests when
+all changed files are Markdown.
 
 ## 2. Workflow
+
 1. Branch off **main** – name `feat/<topic>`  
 2. Keep edits to *distinct* source files where possible.  
 3. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).  
@@ -16,17 +21,19 @@ This file summarises **how to keep the repo healthy**.
 5. A task is *done* only when CI is **all green**.
 
 ## 3. Coding standards
+
 * ≤ 20 lines per function, ≤ 2 nesting levels.
 * 4‑space indent, `black` line length = 88.
 * Validate inputs early; raise on bad data.
 * End every file with a newline; keep Markdown lines ≤ 80 chars.
 
 ## 4. Documentation style
+
 * Use fenced code blocks with language hint.
 * Surround headings/lists/code with blank lines.
-* Run `npx markdownlint-cli '**/*.md'` before pushing.
 
 ## 5. File roles
+
 | File | Purpose |
 |------|---------|
 | `README.md` | user‑facing explainer & quick‑start |
@@ -35,3 +42,4 @@ This file summarises **how to keep the repo healthy**.
 | `AGENTS.md` | *this* contributor guide |
 | `.env` | runtime variables for the sandbox |
 | `setup.sh` | dependency installer |
+| `.github/workflows/ci.yml` | lints & tests in CI |

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,5 @@
+# Engineering notes
+
+- 2025-06-14: Added CI workflow with black, flake8, pytest and markdownlint. Tests
+  skip when commits touch only Markdown. Updated AGENTS and ticked TODO.
+  Reason: bootstrap CI from roadmap.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# CardioRisk-NN-
-Training a lightweight multi‑layer perceptron (MLP) to predict presence of coronary artery disease
-
 # CardioRisk‑NN
+
+Training a lightweight multi‑layer perceptron (MLP) to predict presence of
+coronary artery disease
 
 > **A clinical‑themed, CPU‑only PyTorch prototype that predicts coronary artery
 > disease from 13 routine variables in under 60 s.**
@@ -26,10 +26,14 @@ Training a lightweight multi‑layer perceptron (MLP) to predict presence of cor
 
 ## Quick‑start
 
-# one‑shot run (installs deps on first call)
+### One-shot run (installs deps on first call)
+
+```bash
 make run
-make run calls setup.sh (installs torch, pandas, scikit‑learn)
-and then python train.py --epochs 200.
+```
+
+`make run` calls `setup.sh` to install torch, pandas and scikit-learn then runs
+`python train.py --epochs 200`.
 
 Expected console tail:
 
@@ -60,11 +64,11 @@ python evaluate.py                        # metric‑only re‑run
 All scripts are CPU‑only and keep RAM use < 100 MB.
 
 References
-UCI ML Repository – Heart Disease data set 
+UCI ML Repository – Heart Disease data set
 archive.ics.uci.edu
 
-Kaggle mirror with cleaned CSV 
+Kaggle mirror with cleaned CSV
 kaggle.com
 
-Typical logistic‑regression baseline ROC‑AUC ≈ 0.84‑0.90 
+Typical logistic‑regression baseline ROC‑AUC ≈ 0.84‑0.90
 pmc.ncbi.nlm.nih.gov

--- a/TODO.md
+++ b/TODO.md
@@ -1,33 +1,32 @@
-
----
-
-## `TODO.md`
-
-```markdown
 # TODO – CardioRisk‑NN initial roadmap
 
-*(Created 2025‑06‑14 from empty repo state.)*
+(Created 2025‑06‑14 from empty repo state.)
 
 ## 0. Bootstrap
+
 - [ ] ⬜ Commit starter files (README, NOTES, TODO, AGENTS, .env, setup.sh)
-- [ ] ⬜ Add CI workflow: black, flake8, pytest, markdown‑lint
+- [x] ✅ Add CI workflow: black, flake8, pytest, markdown‑lint
 
 ## 1. Core functionality
+
 - [ ] ⬜ Implement `train.py` MLP with CLI flags (epochs, lr, fast)
 - [ ] ⬜ Implement `evaluate.py` to load saved model & print test metrics
 - [ ] ⬜ Fail `train.py` with exit 1 if ROC‑AUC < 0.90
 
 ## 2. Testing
+
 - [ ] ⬜ `tests/test_smoke.py` – import modules
 - [ ] ⬜ `tests/test_train_fast.py` – 10‑epoch fast run under 20 s
 - [ ] ⬜ `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
 
 ## 3. Documentation
+
 - [ ] ⬜ Flesh out README Quick‑start once CLI stabilises
 - [ ] ⬜ Add model diagram in `docs/overview.md`
 - [ ] ⬜ Publish API reference via Sphinx
 
 ## 4. Stretch goals
+
 - [ ] ⬜ TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [ ] ⬜ Optional calibration script & reliability plot
 - [ ] ⬜ Dockerfile for exact reproducibility


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for black, flake8, pytest and markdownlint
- document the workflow in AGENTS and NOTES
- tick CI task in TODO
- clean up markdown to satisfy lint rules

## Testing
- `npx markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d571c57e48325a99537ca8bab2cda