### PR TITLE
docs: remove stale references and fix duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,23 +14,14 @@ all changed files are Markdown.
 
 ## 2. Workflow
 
-1. Branch off **main** – name `feat/<topic>`  
-2. Keep edits to *distinct* source files where possible.  
-3. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).  
-4. If you change tests, linters, or build scripts, also update **AGENTS.md**.  
-5. A task is *done* only when CI is **all green**.
-
-| Each code commit must pass tests and linters. | Prevents breakage |
-| Docs-only commits run the markdown lint job. | Saves CI minutes |
-
-## 2. Workflow
-
 1. Run `./setup.sh` once after cloning to install the Python deps.
 2. Branch off **main** – name `feat/<topic>`.
 3. Keep edits to *distinct* source files where possible.
 4. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
-5. If you change tests, linters, or build scripts, also update **AGENTS.md**.
-6. A task is *done* only when CI is **all green**.
+5. Run `npx markdownlint-cli '**/*.md'` before pushing.
+6. If you change tests, linters, or build scripts, also update **AGENTS.md**.
+7. A task is *done* only when CI is **all green**.
+   Docs-only commits run only the markdown jobs; code commits run the full test suite.
 
 ## 3. Coding standards
 
@@ -42,11 +33,9 @@ all changed files are Markdown.
 ## 4. Documentation style
 
 * Use fenced code blocks with language hint.
-
 * Surround headings/lists/code with blank lines.
 * Surround headings, lists and code with blank lines.
 * Run `npx markdownlint-cli '**/*.md'` before pushing.
-
 
 ## 5. File roles
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,10 +1,10 @@
 # Engineering notes
 
-- 2025-06-14: Added CI workflow with black, flake8, pytest and markdownlint. Tests
-  skip when commits touch only Markdown. Updated AGENTS and ticked TODO.
+- 2025-06-14: Added CI workflow with black, flake8, pytest and markdownlint.
+  Tests skip when commits touch only Markdown. Updated AGENTS and ticked TODO.
   Reason: bootstrap CI from roadmap.
 
-- 2025-06-14: Added setup.sh for installing PyTorch CPU, pandas and scikit-learn
+- 2025-06-14: Added setup.sh for CPU-only PyTorch, pandas and scikit-learn.
   Created sample .env file. Updated AGENTS workflow per TODO.
 
 - 2025-07-03: Created log file and cleaned README placeholders.
@@ -14,5 +14,9 @@
 - 2025-06-14: Initial project scaffold with README, TODO, AGENTS and LICENSE.
   No code or CI yet.
 
-- 2025-06-14: added Cleveland dataset and empty train.py placeholder. Reason: prepare for training scripts.
-Decisions: used UCI CSV and simple main guard as per TODO roadmap.
+- 2025-06-14: added Cleveland dataset and empty train.py placeholder.
+  Reason: prepare for training scripts.
+  Decisions: used UCI CSV and simple main guard as per TODO roadmap.
+- 2025-07-05: Cleaned README duplication and removed stale references.
+  Merged AGENTS workflow sections and kept single roadmap in TODO.
+  Reason: tidy docs and reflect actual CI behaviour.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,9 @@
-# CardioRisk‑NN
-
-Training a lightweight multi‑layer perceptron (MLP) to predict presence of
-coronary artery disease
-
-> **A clinical‑themed, CPU‑only PyTorch prototype that predicts coronary artery
-> disease from 13 routine variables in under 60 s.**
-
 <!-- markdownlint-disable MD013 -->
 # CardioRisk-NN
 
 Training a lightweight multi-layer perceptron (MLP) to predict coronary artery disease.
 
 > **A clinical-themed, CPU-only PyTorch prototype that predicts coronary artery disease from 13 routine variables in under 60 s.**
-
 
 [![Build & Test](https://img.shields.io/github/actions/workflow/status/example/CardioRisk-NN/ci.yml?branch=main)](https://github.com/example/CardioRisk-NN/actions)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
@@ -34,21 +25,11 @@ Training a lightweight multi-layer perceptron (MLP) to predict coronary artery d
 
 ## Quick-start
 
-
 ### One-shot run (installs deps on first call)
 
 ```bash
-make run
+bash setup.sh && python train.py --epochs 200
 ```
-
-`make run` calls `setup.sh` to install torch, pandas and scikit-learn then runs
-`python train.py --epochs 200`.
-
-```bash
-# install deps on first call, then run full training
-make run
-```
-
 
 Expected console tail:
 
@@ -63,14 +44,12 @@ Repository layout:
 data/heart.csv        ← 303 × 14 (13 features + target)
 setup.sh              ← fast dependency installer (≤ 45 s)
 train.py              ← full train + evaluation
-quick_test.sh         ← 10-epoch smoke test (<15 s)
-requirements.txt      ← pinned deps for CI
 .env                  ← runner configuration (see below)
 README.md             ← you are here
 TODO.md               ← roadmap tasks
 NOTES.md              ← running decisions log
 AGENTS.md             ← contributor & CI guidelines
-.github/workflows/    ← CI pipeline (to be added)
+.github/workflows/ci.yml ← CI pipeline
 ```
 
 Command-line options:
@@ -78,20 +57,9 @@ Command-line options:
 ```bash
 python train.py --epochs 200 --lr 1e-3    # default full run
 python train.py --epochs 10 --fast        # smoke test
-python evaluate.py                        # metric-only re-run
 ```
 
 All scripts are CPU-only and keep RAM use < 100 MB.
-
-References
-UCI ML Repository – Heart Disease data set
-archive.ics.uci.edu
-
-Kaggle mirror with cleaned CSV
-kaggle.com
-
-Typical logistic‑regression baseline ROC‑AUC ≈ 0.84‑0.90
-pmc.ncbi.nlm.nih.gov
 
 ---
 
@@ -100,4 +68,3 @@ pmc.ncbi.nlm.nih.gov
 * [UCI ML Repository – Heart Disease data set](https://archive.ics.uci.edu)
 * [Kaggle mirror with cleaned CSV](https://kaggle.com)
 * [Typical logistic-regression baseline ROC-AUC ≈ 0.84-0.90](https://pmc.ncbi.nlm.nih.gov)
-

--- a/TODO.md
+++ b/TODO.md
@@ -1,43 +1,11 @@
-# TODO – CardioRisk‑NN initial roadmap
-
-(Created 2025‑06‑14 from empty repo state.)
-
-## 0. Bootstrap
-
-- [ ] ⬜ Commit starter files (README, NOTES, TODO, AGENTS, .env, setup.sh)
-- [x] ✅ Add CI workflow: black, flake8, pytest, markdown‑lint
-
-## 1. Core functionality
-
-- [ ] ⬜ Implement `train.py` MLP with CLI flags (epochs, lr, fast)
-- [ ] ⬜ Implement `evaluate.py` to load saved model & print test metrics
-- [ ] ⬜ Fail `train.py` with exit 1 if ROC‑AUC < 0.90
-
-## 2. Testing
-
-- [ ] ⬜ `tests/test_smoke.py` – import modules
-- [ ] ⬜ `tests/test_train_fast.py` – 10‑epoch fast run under 20 s
-- [ ] ⬜ `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
-
-## 3. Documentation
-
-- [ ] ⬜ Flesh out README Quick‑start once CLI stabilises
-- [ ] ⬜ Add model diagram in `docs/overview.md`
-- [ ] ⬜ Publish API reference via Sphinx
-
-## 4. Stretch goals
-
-- [ ] ⬜ TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
-- [ ] ⬜ Optional calibration script & reliability plot
-- [ ] ⬜ Dockerfile for exact reproducibility
-
 # TODO – CardioRisk-NN initial roadmap
 
 > Created 2025-06-14 from empty repo state.
 
 ## 0. Bootstrap
+
 - [x] ✅ Commit starter files (README, NOTES, TODO, AGENTS, .env, setup.sh)
-- [ ] ⬜ Add CI workflow: black, flake8, pytest, markdown‑lint
+- [x] ✅ Add CI workflow: black, flake8, pytest, markdown-lint
 - [x] ✅ Vendored Cleveland dataset `data/heart.csv`
 - [x] ✅ Add placeholder `train.py`
 
@@ -65,4 +33,3 @@
 - [ ] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [ ] Optional calibration script & reliability plot
 - [ ] Dockerfile for exact reproducibility
-


### PR DESCRIPTION
## Summary
- cleaned duplicate sections in README
- removed references to missing files and updated CI notes
- merged AGENTS workflow sections into one
- kept a single TODO roadmap and fixed numbering
- logged these doc fixes in NOTES

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684d5b76fbc48325aefd31a0d64d68d1