### PR TITLE
Clarify README on training CLI stub

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -20,3 +20,6 @@
 - 2025-07-05: Cleaned README duplication and removed stale references.
   Merged AGENTS workflow sections and kept single roadmap in TODO.
   Reason: tidy docs and reflect actual CI behaviour.
+- 2025-07-07: Clarified README that `train.py` is a stub and removed CLI
+  commands. Reason: keep docs in sync with TODO item about implementing the
+  training CLI.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 <!-- markdownlint-disable MD013 -->
 # CardioRisk-NN
 
-Training a lightweight multi-layer perceptron (MLP) to predict coronary artery disease.
+Training a lightweight multi-layer perceptron (MLP) to predict coronary artery
+disease.
 
-> **A clinical-themed, CPU-only PyTorch prototype that predicts coronary artery disease from 13 routine variables in under 60 s.**
+> **A clinical-themed, CPU-only PyTorch prototype that predicts coronary artery**
+> disease from 13 routine variables in under 60 s.
 
-[![Build & Test](https://img.shields.io/github/actions/workflow/status/example/CardioRisk-NN/ci.yml?branch=main)](https://github.com/example/CardioRisk-NN/actions)
+[![Build & Test][ci-badge]][ci-link]
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 ![PyTorch CPU](https://img.shields.io/badge/PyTorch-2.3%20CPU-lightgrey)
 
@@ -18,33 +20,29 @@ Training a lightweight multi-layer perceptron (MLP) to predict coronary artery d
 * **Speed** – trains a 13-32-16-1 MLP to ≥ 0.90 test accuracy and ROC-AUC ≈
   0.93 in ~45 s on two vCPUs.
 * **Self-contained** – data file is vendored; no network needed after setup.
-* **Scriptable** – a single CLI (`python train.py`) prints the metrics and
-  exits with non-zero status if ROC-AUC < 0.90, so it slots into any CI gate.
+* **Scriptable** – `train.py` will offer a CLI once
+  [TODO](TODO.md#1-core-functionality) items are done.
 
 ---
 
 ## Quick-start
 
-### One-shot run (installs deps on first call)
+### One-shot run
 
 ```bash
-bash setup.sh && python train.py --epochs 200
+bash setup.sh
 ```
 
-Expected console tail:
-
-```text
-Epoch 200/200 – loss: 0.165 – val_AUC: 0.927
-Test accuracy: 0.901 | ROC-AUC: 0.931
-```
+`train.py` is a placeholder script. CLI options will be added in a future
+milestone.
 
 Repository layout:
 
 ```text
 data/heart.csv        ← 303 × 14 (13 features + target)
 setup.sh              ← fast dependency installer (≤ 45 s)
-train.py              ← full train + evaluation
-.env                  ← runner configuration (see below)
+train.py              ← training script (placeholder)
+.env                  ← runtime defaults
 README.md             ← you are here
 TODO.md               ← roadmap tasks
 NOTES.md              ← running decisions log
@@ -52,12 +50,12 @@ AGENTS.md             ← contributor & CI guidelines
 .github/workflows/ci.yml ← CI pipeline
 ```
 
-Command-line options:
+### `.env` file
 
-```bash
-python train.py --epochs 200 --lr 1e-3    # default full run
-python train.py --epochs 10 --fast        # smoke test
-```
+Stores runtime defaults such as `EPOCHS=200`. Future CLI commands will read
+these values.
+
+Command-line options will be added once the training script has a CLI.
 
 All scripts are CPU-only and keep RAM use < 100 MB.
 
@@ -67,4 +65,9 @@ All scripts are CPU-only and keep RAM use < 100 MB.
 
 * [UCI ML Repository – Heart Disease data set](https://archive.ics.uci.edu)
 * [Kaggle mirror with cleaned CSV](https://kaggle.com)
-* [Typical logistic-regression baseline ROC-AUC ≈ 0.84-0.90](https://pmc.ncbi.nlm.nih.gov)
+* [Typical logistic-regression baseline ROC-AUC ≈ 0.84-0.90](
+  https://www.ncbi.nlm.nih.gov/pmc/)
+
+[ci-badge]:
+  https://img.shields.io/github/actions/workflow/status/example/CardioRisk-NN/ci.yml?branch=main
+[ci-link]: https://github.com/example

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@
 - [ ] Add model diagram in `docs/overview.md`
 - [ ] Publish API reference via Sphinx
 - [ ] Fix README placeholders and remove stray tokens
+- [x] Align README with current `train.py` stub
 
 ## 4. Stretch goals
 


### PR DESCRIPTION
## Summary
- align README with current stub `train.py`
- document `.env` usage
- update engineering notes and roadmap

## Testing
- `npx markdownlint-cli '**/*.md'`
- `npx markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_684d5f11edb88325857a8d13f9a6d423