### PR TITLE
Pin PyTorch 2.3 in setup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -25,3 +25,7 @@
   training CLI.
 - 2025-07-09: Marked README placeholders task done in TODO.
   Reason: reflect prior docs cleanup; decisions: none.
+
+- 2025-07-10: Pinned `torch==2.3.*` in `setup.sh` and documented the pin in
+  `README`. Reason: keep installs reproducible on CPU-only boxes; decisions:
+  limit to minor version to stay compatible with docs.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ disease.
 bash setup.sh
 ```
 
+`setup.sh` installs **PyTorch 2.3.x** from the CPU wheel index so runs stay
+GPU-free and reproducible.
+
 `train.py` is a placeholder script. CLI options will be added in a future
 milestone.
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 - [x] ✅ Add CI workflow: black, flake8, pytest, markdown-lint
 - [x] ✅ Vendored Cleveland dataset `data/heart.csv`
 - [x] ✅ Add placeholder `train.py`
+- [x] ✅ Pin `torch==2.3.*` in setup.sh for CPU-only installs
 
 ## 1. Core functionality
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 set -e
 
 # CPU-only PyTorch
-pip install --extra-index-url https://download.pytorch.org/whl/cpu torch
+pip install --extra-index-url https://download.pytorch.org/whl/cpu torch==2.3.*
 
 # Core libraries
 pip install pandas scikit-learn


### PR DESCRIPTION
## Summary
- pin torch==2.3.* in setup.sh
- mention the CPU wheel pin in the README
- log the pin in NOTES
- tick roadmap item in TODO

## Testing
- `npx markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_684d625dab088325a833cf7af80ec23d