### PR TITLE
Add MLP overview diagram

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -29,3 +29,5 @@
 - 2025-07-10: Pinned `torch==2.3.*` in `setup.sh` and documented the pin in
   `README`. Reason: keep installs reproducible on CPU-only boxes; decisions:
   limit to minor version to stay compatible with docs.
+- 2025-07-12: Added docs/overview.md with MLP sketch and linked from README.
+  Reason: implement TODO diagram; decisions: simple ASCII for clarity.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ AGENTS.md             ← contributor & CI guidelines
 .github/workflows/ci.yml ← CI pipeline
 ```
 
+See [docs/overview.md](docs/overview.md) for a sketch of the MLP and
+the training workflow.
+
 ### `.env` file
 
 Stores runtime defaults such as `EPOCHS=200`. Future CLI commands will read

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,8 @@
 ## 3. Documentation
 
 - [ ] Flesh out README Quick-start once CLI stabilises
-- [ ] Add model diagram in `docs/overview.md`
+- [x] Add model diagram in `docs/overview.md`
+- [ ] Document CLI usage in `docs/overview.md` once the training script has a CLI
 - [ ] Publish API reference via Sphinx
 - [x] Fix README placeholders and remove stray tokens
 - [x] Align README with current `train.py` stub

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+# Project overview
+
+This document sketches the simple multi-layer perceptron (MLP) and the basic
+training workflow.
+
+## Network architecture
+
+```text
+13 features → [Linear 13→32] → ReLU
+            → [Linear 32→16] → ReLU
+            → [Linear 16→1 ] → Sigmoid
+```
+
+The model predicts the probability of coronary artery disease from 13 numeric
+inputs.
+
+## Workflow steps
+
+1. Install dependencies with `bash setup.sh`.
+2. Run `python train.py` (CLI flags will be added later).
+3. Analyse test metrics once the CLI exposes them.
+
+Future docs will detail the dataset and training options once implemented.


### PR DESCRIPTION
## Summary
- include an architecture diagram and workflow notes in docs/overview.md
- link the new doc from README
- record the change in NOTES
- mark TODO item as done and add a follow-up task

## Testing
- `npx markdownlint-cli '**/*.md'`
- `npx markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_684d67907ac88325af808c406636bbc2