### PR TITLE
Add smoke tests and minimal train/eval

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -29,3 +29,6 @@
 - 2025-07-10: Pinned `torch==2.3.*` in `setup.sh` and documented the pin in
   `README`. Reason: keep installs reproducible on CPU-only boxes; decisions:
   limit to minor version to stay compatible with docs.
+- 2025-07-11: Added basic MLP training and evaluation modules with tests for
+  fast run and ROC-AUC. Reason: implement TODO testing tasks; decisions: used
+  scikit-learn MLP for speed.

--- a/TODO.md
+++ b/TODO.md
@@ -18,9 +18,9 @@
 
 ## 2. Testing
 
-- [ ] `tests/test_smoke.py` – import modules
-- [ ] `tests/test_train_fast.py` – 10-epoch fast run under 20 s
-- [ ] `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
+- [x] `tests/test_smoke.py` – import modules
+- [x] `tests/test_train_fast.py` – 10-epoch fast run under 20 s
+- [x] `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
 
 ## 3. Documentation
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,16 @@
+"""Evaluation helpers for CardioRisk-NN."""
+
+from train import train_model
+
+
+def evaluate(seed: int = 0) -> float:
+    return train_model(fast=True, seed=seed)
+
+
+def main(args=None):
+    auc = evaluate()
+    print(f"ROC-AUC: {auc:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from evaluate import evaluate  # noqa: E402
+
+
+def test_roc_auc():
+    auc = evaluate(seed=0)
+    assert auc >= 0.85

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import train  # noqa: E402
+import evaluate  # noqa: E402
+
+
+def test_imports():
+    assert hasattr(train, "main")
+    assert hasattr(evaluate, "main")

--- a/tests/test_train_fast.py
+++ b/tests/test_train_fast.py
@@ -1,0 +1,12 @@
+import time
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import train  # noqa: E402
+
+
+def test_fast_training_runs_under_20s():
+    start = time.time()
+    train.main(["--fast"])
+    assert time.time() - start < 20

--- a/train.py
+++ b/train.py
@@ -1,9 +1,47 @@
-"""Model training entry point."""
+"""Train an MLP on the heart disease dataset."""
+
+import argparse
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import train_test_split
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import StandardScaler
 
 
-def main():
-    """TODO: implement training"""
-    pass
+def _load_split(seed: int):
+    df = pd.read_csv("data/heart.csv").replace("?", np.nan).astype(float)
+    df.fillna(df.mean(), inplace=True)
+    y = (df.pop("target") > 0).astype(int)
+    x_train, x_test, y_train, y_test = train_test_split(
+        df, y, test_size=0.2, random_state=seed, stratify=y
+    )
+    scaler = StandardScaler()
+    x_train = scaler.fit_transform(x_train)
+    x_test = scaler.transform(x_test)
+    return x_train, x_test, y_train, y_test
+
+
+def train_model(fast: bool, seed: int) -> float:
+    x_train, x_test, y_train, y_test = _load_split(seed)
+    epochs = 10 if fast else 200
+    clf = MLPClassifier(
+        hidden_layer_sizes=(32, 16),
+        max_iter=epochs,
+        random_state=seed,
+    )
+    clf.fit(x_train, y_train)
+    proba = clf.predict_proba(x_test)[:, 1]
+    return roc_auc_score(y_test, proba)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fast", action="store_true")
+    parser.add_argument("--seed", type=int, default=0)
+    parsed = parser.parse_args(args)
+    auc = train_model(parsed.fast, parsed.seed)
+    print(f"ROC-AUC: {auc:.3f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement simple sklearn MLP training and evaluation helpers
- add unit tests for imports, fast training and ROC-AUC
- document the work in NOTES and tick TODO items

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d678ef64c8325985b092f7d1ce126