### PR TITLE
Refactor evaluate loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+dist/
+*.egg-info/
+.env
+
+

--- a/NOTES.md
+++ b/NOTES.md
@@ -44,3 +44,7 @@
 
 - 2025-07-12: Added docs/overview.md with MLP sketch and linked from README.
   Reason: implement TODO diagram; decisions: simple ASCII for clarity.
+- 2025-07-13: Refactored evaluate.py to keep seed-based evaluate for tests and
+  introduced evaluate_saved_model for loading saved models. Updated CLI to use
+  the new function and removed duplicate main. Reason: avoid function override
+  issues; decisions: rename for clarity per instructions.

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 
 
 - [x] Implement `train.py` MLP with CLI flags (epochs, lr, fast)
-- [ ] Implement `evaluate.py` to load saved model & print test metrics
+- [x] Implement `evaluate.py` to load saved model & print test metrics
 - [x] Fail `train.py` with exit 1 if ROC-AUC < 0.90
 
 - [ ] Implement `train.py` MLP with CLI flags (epochs, lr, fast)

--- a/evaluate.py
+++ b/evaluate.py
@@ -7,10 +7,6 @@ def evaluate(seed: int = 0) -> float:
     return train_model(fast=True, seed=seed)
 
 
-def main(args=None):
-    auc = evaluate()
-    print(f"ROC-AUC: {auc:.3f}")
-
 import argparse
 from pathlib import Path
 
@@ -29,7 +25,7 @@ def load_data(batch_size: int = 64) -> DataLoader:
     return DataLoader(dataset, batch_size=batch_size)
 
 
-def evaluate(model_path: Path) -> float:
+def evaluate_saved_model(model_path: Path) -> float:
     """Load a saved model and print ROC-AUC."""
     loader = load_data()
     model = torch.load(model_path, map_location="cpu")
@@ -53,7 +49,7 @@ def main() -> None:
         "--model-path", default="model.pt", type=Path, help="Path to .pt file"
     )
     args = parser.parse_args()
-    evaluate(args.model_path)
+    evaluate_saved_model(args.model_path)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- split `evaluate()` into `evaluate` (seed-based) and `evaluate_saved_model`
- wire CLI to call `evaluate_saved_model`
- add missing `.gitignore`
- update NOTES and TODO roadmap

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6dc6036083258a3d0112e3e0dc52