### PR TITLE
Fix readme and docs after sklearn switch

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -61,3 +61,7 @@
   introduced evaluate_saved_model for loading saved models. Updated CLI to use
   the new function and removed duplicate main. Reason: avoid function override
   issues; decisions: rename for clarity per instructions.
+
+- 2025-07-15: Cleaned README and overview docs after scikit-learn migration.
+  Clarified `--fast`, `--model-path` and `model.pkl` behaviour. Reason: align
+  documentation with the simplified trainer.

--- a/README.md
+++ b/README.md
@@ -38,17 +38,14 @@ GPU-free and reproducible.
 Run the training script with, for example:
 
 ```bash
-python train.py --epochs 200 --lr 0.01
+python train.py --seed 0
 ```
 
+Add `--fast` for a 10‑epoch demo and `--model-path` to set the output file.
+The script saves `model.pkl` and exits with status 1 when ROC-AUC is below
+0.90. `evaluate.py` runs a quick training to report ROC‑AUC.
 
-Add `--fast` to run a short 10‑epoch demo. The script saves `model.pkl` and
-exits with status 1 when ROC-AUC is below 0.90. Use `--seed` for reproducible
-results. `evaluate.py` runs a quick training to report ROC-AUC.
-
-Add `--fast` to run a short 10-epoch demo. Use `--seed` to fix the random
-split.
-`train.py` trains the MLP and saves `model.pt` when ROC-AUC ≥ 0.90.
+`train.py` trains the MLP and saves `model.pkl` when ROC‑AUC ≥ 0.90.
 `evaluate.py` loads this file and prints the metric.
 
 Repository layout:
@@ -57,11 +54,7 @@ Repository layout:
 data/heart.csv        ← 303 × 14 (13 features + target)
 setup.sh              ← fast dependency installer (≤ 45 s)
 
-
-train.py              ← training script
-=======
 train.py              ← MLP training script
-
 evaluate.py           ← model metrics helper
 
 .env                  ← runtime defaults

--- a/TODO.md
+++ b/TODO.md
@@ -30,6 +30,7 @@
 - [ ] Publish API reference via Sphinx
 - [x] Fix README placeholders and remove stray tokens
 - [x] Align README with current `train.py` stub
+- [x] Refresh README/doc overview after scikit-learn migration
 
 ## 4. Stretch goals
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,10 +19,7 @@ inputs.
 1. Install dependencies with `bash setup.sh`.
 
 2. Run `python train.py --fast --seed 0` for a quick demo.
+
 3. The script saves `model.pkl` and exits with code `1` if ROC-AUC < 0.90.
-
-2. Run `python train.py --fast` for a quick demo.
-3. Analyse test metrics once the CLI exposes them.
-
 
 Future docs will detail the dataset and training options once implemented.


### PR DESCRIPTION
## Summary
- update README quick-start example and layout
- clean conflict markers and duplicate lines
- fix docs/overview numbering
- log the cleanup in NOTES and mark TODO

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684d70e32b248325a11164f66bebe451