### PR TITLE
Fix evaluate README docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -67,3 +67,6 @@
   documentation with the simplified trainer.
 - 2025-07-16: Clarified evaluate.py quick run default and `.env` unused.
   Reason: docs cleanup.
+
+- 2025-07-17: Documented evaluate.py default model path and test helper in
+  README. Reason: keep docs synced with evaluate.py behaviour.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ file. The script saves `model.pkl` and exits with status 1 when ROC‑AUC is bel
 0.90.
 
 `train.py` trains the MLP and saves `model.pkl` when ROC‑AUC ≥ 0.90.
-`evaluate.py` runs a quick training by default and prints ROC‑AUC. Pass
-`--model-path file.pt` to load a saved `.pt` model instead.
+`evaluate.py` loads a saved `model.pt` by default via the `--model-path`
+argument and prints ROC‑AUC. The module's `evaluate()` function (not the CLI)
+performs a short training run used in the tests.
 
 Repository layout:
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,8 @@
 - [x] Fix README placeholders and remove stray tokens
 - [x] Align README with current `train.py` stub
 - [x] Refresh README/doc overview after scikit-learn migration
+- [x] Clarify in README that `evaluate.py` loads `model.pt` by default and that
+  `evaluate()` runs the short training used in tests
 
 ## 4. Stretch goals
 


### PR DESCRIPTION
## Summary
- clarify evaluate.py loading and quick-run usage in README
- log doc update in NOTES
- record roadmap completion in TODO

## Testing
- `npx markdownlint-cli '**/*.md'`
- `npx markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_684d778ad3dc8325b9721e2d1328867b