### PR TITLE
Update TODO for PyTorch training

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -70,3 +70,5 @@
 
 - 2025-07-17: Documented evaluate.py default model path and test helper in
   README. Reason: keep docs synced with evaluate.py behaviour.
+- 2025-07-18: Added TODO item to migrate training script to PyTorch to
+  highlight core PyTorch skills. Reason: match future showcase goal.

--- a/TODO.md
+++ b/TODO.md
@@ -39,3 +39,4 @@
 - [ ] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [ ] Optional calibration script & reliability plot
 - [ ] Dockerfile for exact reproducibility
+- [ ] Switch `train.py` to a PyTorch loop using `build_mlp`


### PR DESCRIPTION
## Summary
- list a new roadmap bullet to migrate `train.py` to a torch-based loop
- log the decision in NOTES

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684d7a3974148325b28221a041f95320