### PR TITLE
Cleanup evaluate entrypoint

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -72,3 +72,7 @@
   README. Reason: keep docs synced with evaluate.py behaviour.
 - 2025-07-18: Added TODO item to migrate training script to PyTorch to
   highlight core PyTorch skills. Reason: match future showcase goal.
+
+- 2025-07-19: Removed redundant `main(args=None)` wrapper from
+  `evaluate.py` and moved imports to the top. Reason: cleanup duplicate
+  entry point so tests and flake8 pass.

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 - [x] Implement `train.py` MLP with CLI flags (epochs, lr, fast)
 - [x] Implement `evaluate.py` to load saved model & print test metrics
 - [x] Fail `train.py` with exit 1 if ROC-AUC < 0.90
+- [x] Remove duplicate `main(args=None)` from `evaluate.py`
 
 ## 2. Testing
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,19 +1,5 @@
 """Evaluation helpers for CardioRisk-NN."""
 
-from train import train_model
-
-
-def evaluate(seed: int = 0) -> float:
-    """Run a short training to compute ROC-AUC."""
-    return train_model(fast=True, seed=seed, model_path=None)
-
-
-
-def main(args=None) -> None:
-    auc = evaluate()
-    print(f"ROC-AUC: {auc:.3f}")
-
-
 import argparse
 from pathlib import Path
 
@@ -21,6 +7,13 @@ import pandas as pd
 import torch
 from sklearn.metrics import roc_auc_score
 from torch.utils.data import DataLoader, TensorDataset
+
+from train import train_model
+
+
+def evaluate(seed: int = 0) -> float:
+    """Run a short training to compute ROC-AUC."""
+    return train_model(fast=True, seed=seed, model_path=None)
 
 
 def load_data(batch_size: int = 64) -> DataLoader:


### PR DESCRIPTION
## Summary
- remove redundant `main(args=None)` from `evaluate.py`
- move imports to the top for flake8
- document cleanup in NOTES
- mark TODO done

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d815914ec8325a0c1ea430fa7e9e6