### PR TITLE
Add Sphinx docs and CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install black flake8 pytest
+          pip install black flake8 pytest sphinx
 
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
@@ -55,6 +55,9 @@ jobs:
       - name: Run pytest
         if: steps.docs.outputs.docs_only == 'false'
         run: pytest -v
+
+      - name: Build docs
+        run: sphinx-build -b html docs/source docs/_build
 
       - name: Check links
         run: npx markdown-link-check README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This file summarises **how to keep the repo healthy**.
 
 The pipeline lives at `.github/workflows/ci.yml` and skips tests when
 all changed files are Markdown.
+It always builds the Sphinx docs with `sphinx-build`.
 
 ## 2. Workflow
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -72,3 +72,5 @@
   README. Reason: keep docs synced with evaluate.py behaviour.
 - 2025-07-18: Added TODO item to migrate training script to PyTorch to
   highlight core PyTorch skills. Reason: match future showcase goal.
+- 2025-07-19: Added Sphinx docs scaffold and CI docs build step.
+  Reason: complete TODO item on publishing API docs via Sphinx.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ environment variables.
 
 All scripts are CPU-only and keep RAM use < 100 MB.
 
+### Building the docs
+
+Install Sphinx and run:
+
+```bash
+sphinx-build -b html docs/source docs/_build
+```
+
+The HTML pages appear in `docs/_build`.
+
 ---
 
 ## References

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
 - [x] Flesh out README Quick-start once CLI stabilises
 - [x] Add model diagram in `docs/overview.md`
 - [x] Document CLI usage in `docs/overview.md` once the training script has a CLI
-- [ ] Publish API reference via Sphinx
+- [x] Publish API reference via Sphinx
 - [x] Fix README placeholders and remove stray tokens
 - [x] Align README with current `train.py` stub
 - [x] Refresh README/doc overview after scikit-learn migration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+# Add project root to path so autodoc can import modules
+sys.path.insert(0, os.path.abspath("../.."))
+
+project = "CardioRisk-NN"
+author = "Example"
+
+extensions = ["sphinx.ext.autodoc"]
+
+html_theme = "alabaster"
+
+templates_path = ["_templates"]
+exclude_patterns = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,14 @@
+CardioRisk-NN API
+=================
+
+.. automodule:: train
+   :members:
+
+.. automodule:: evaluate
+   :members:
+
+.. automodule:: model
+   :members:
+
+.. automodule:: data_utils
+   :members:

--- a/evaluate.py
+++ b/evaluate.py
@@ -8,7 +8,6 @@ def evaluate(seed: int = 0) -> float:
     return train_model(fast=True, seed=seed, model_path=None)
 
 
-
 def main(args=None) -> None:
     auc = evaluate()
     print(f"ROC-AUC: {auc:.3f}")


### PR DESCRIPTION
## Summary
- scaffold Sphinx in `docs/source`
- publish docs automatically by calling `sphinx-build` in CI
- show how to build the docs locally in the README
- log the decision in `NOTES.md` and tick TODO
- clarify CI policy in `AGENTS.md`

## Testing
- `bash setup.sh`
- `pip install black flake8 pytest sphinx`
- `black --check .`
- `flake8 .`
- `pytest -q`
- `npx markdownlint-cli '**/*.md'`
- `sphinx-build -b html docs/source docs/_build`


------
https://chatgpt.com/codex/tasks/task_e_684d815a39ec832598cfbf40e53fc03d