### PR TITLE
Clean TODO duplicates

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -87,3 +87,7 @@
 - 2025-07-19: Removed redundant `main(args=None)` wrapper from
   `evaluate.py` and moved imports to the top. Reason: cleanup duplicate
   entry point so tests and flake8 pass.
+- 2025-07-20: Marked Dockerfile and PyTorch loop tasks done in TODO and
+  removed duplicate lines. Reason: tidy roadmap and reflect current
+  code state. Decisions: verified `train.py` uses `build_mlp` and
+  Dockerfile exists.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ environment variables.
 
 All scripts are CPU-only and keep RAM use < 100 MB.
 
-
 ### Docker usage
 
 An optional container builds from the repo and installs packages via
@@ -99,7 +98,6 @@ sphinx-build -b html docs/source docs/_build
 ```
 
 The HTML pages appear in `docs/_build`.
-
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -39,8 +39,5 @@
 
 - [ ] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [ ] Optional calibration script & reliability plot
-- [ ] Dockerfile for exact reproducibility
-- [x] Switch `train.py` to a PyTorch loop using `build_mlp`
-
 - [x] Dockerfile for exact reproducibility
-- [ ] Switch `train.py` to a PyTorch loop using `build_mlp`
+- [x] Switch `train.py` to a PyTorch loop using `build_mlp`


### PR DESCRIPTION
## Summary
- remove duplicate stretch goals from TODO
- fix README blank line lint errors
- log cleanup in NOTES

## Testing
- `npx -y markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684d86d39fa483258f980d0a09fc8a47