### PR TITLE
Remove unused .env file and docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# Sample runtime configuration
-EPOCHS=200

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,6 @@ It always builds the Sphinx docs with `sphinx-build`.
 | `TODO.md` | roadmap of work items |
 | `NOTES.md` | chronological engineering log |
 | `AGENTS.md` | *this* contributor guide |
-| `.env` | runtime variables for the sandbox |
 | `setup.sh` | dependency installer |
 | `.github/workflows/ci.yml` | lints & tests in CI |
 | `Dockerfile` | optional container image |

--- a/NOTES.md
+++ b/NOTES.md
@@ -87,3 +87,7 @@
 - 2025-07-19: Removed redundant `main(args=None)` wrapper from
   `evaluate.py` and moved imports to the top. Reason: cleanup duplicate
   entry point so tests and flake8 pass.
+
+- 2025-07-20: Removed unused `.env` file and cleaned docs.
+  Reason: default epochs come from code; no env vars used.
+  Updated README and AGENTS to stay consistent.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ setup.sh              ← fast dependency installer (≤ 45 s)
 train.py              ← MLP training script
 evaluate.py           ← model metrics helper
 
-.env                  ← unused placeholder
 README.md             ← you are here
 TODO.md               ← roadmap tasks
 NOTES.md              ← running decisions log
@@ -69,14 +68,6 @@ AGENTS.md             ← contributor & CI guidelines
 
 See [docs/overview.md](docs/overview.md) for a sketch of the MLP and
 the training workflow.
-
-### `.env` file
-
-This file is currently unused and only kept as a placeholder for potential
-environment variables.
-
-All scripts are CPU-only and keep RAM use < 100 MB.
-
 
 ### Docker usage
 
@@ -99,7 +90,6 @@ sphinx-build -b html docs/source docs/_build
 ```
 
 The HTML pages appear in `docs/_build`.
-
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
 - [x] Implement `evaluate.py` to load saved model & print test metrics
 - [x] Fail `train.py` with exit 1 if ROC-AUC < 0.90
 - [x] Remove duplicate `main(args=None)` from `evaluate.py`
+- [x] Remove unused `.env` file; docs updated accordingly
 
 ## 2. Testing
 


### PR DESCRIPTION
## Summary
- remove placeholder `.env`
- clean documentation to match
- note change and tick TODO item

## Testing
- `npx markdownlint-cli '**/*.md'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d86d454b48325914abcfacbad9df9