### PR TITLE
Add model calibration helper

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -87,3 +87,6 @@
 - 2025-07-19: Removed redundant `main(args=None)` wrapper from
   `evaluate.py` and moved imports to the top. Reason: cleanup duplicate
   entry point so tests and flake8 pass.
+- 2025-07-20: Added calibrate.py with Brier score and reliability plot.
+  Tests cover fast model calibration. Updated README, Sphinx docs and
+  setup.sh. Reason: implement optional calibration feature from TODO.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ file. The script saves `model.pt` and exits with status 1 when ROC‑AUC is belo
 `evaluate.py` loads a saved `model.pt` by default via the `--model-path`
 argument and prints ROC‑AUC. The module's `evaluate()` function (not the CLI)
 performs a short training run used in the tests.
+`calibrate.py` reports the Brier score and saves a reliability plot image for
+any saved model.
 
 Repository layout:
 
@@ -58,6 +60,7 @@ setup.sh              ← fast dependency installer (≤ 45 s)
 
 train.py              ← MLP training script
 evaluate.py           ← model metrics helper
+calibrate.py          ← reliability plot helper
 
 .env                  ← unused placeholder
 README.md             ← you are here
@@ -74,9 +77,7 @@ the training workflow.
 
 This file is currently unused and only kept as a placeholder for potential
 environment variables.
-
 All scripts are CPU-only and keep RAM use < 100 MB.
-
 
 ### Docker usage
 
@@ -99,7 +100,6 @@ sphinx-build -b html docs/source docs/_build
 ```
 
 The HTML pages appear in `docs/_build`.
-
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
 
 - [x] Flesh out README Quick-start once CLI stabilises
 - [x] Add model diagram in `docs/overview.md`
-- [x] Document CLI usage in `docs/overview.md` once the training script has a CLI
+- [x] Document CLI usage in `docs/overview.md` once training has a CLI
 - [x] Publish API reference via Sphinx
 - [x] Fix README placeholders and remove stray tokens
 - [x] Align README with current `train.py` stub
@@ -38,7 +38,7 @@
 ## 4. Stretch goals
 
 - [ ] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
-- [ ] Optional calibration script & reliability plot
+- [x] Optional calibration script & reliability plot
 - [ ] Dockerfile for exact reproducibility
 - [x] Switch `train.py` to a PyTorch loop using `build_mlp`
 

--- a/calibrate.py
+++ b/calibrate.py
@@ -1,0 +1,47 @@
+"""Calibration helper for CardioRisk-NN."""
+
+import argparse
+from pathlib import Path
+
+import torch
+from sklearn.calibration import CalibrationDisplay
+from sklearn.metrics import brier_score_loss
+import matplotlib.pyplot as plt
+
+from evaluate import load_data
+
+
+def calibrate_model(model_path: Path, plot_path: Path) -> float:
+    """Compute Brier score and save reliability plot."""
+    loader = load_data()
+    model = torch.load(model_path, map_location="cpu")
+    model.eval()
+
+    probs, labels = [], []
+    with torch.no_grad():
+        for features, target in loader:
+            logits = model(features).squeeze()
+            prob = torch.sigmoid(logits)
+            probs.extend(prob.tolist())
+            labels.extend(target.tolist())
+
+    brier = brier_score_loss(labels, probs)
+    disp = CalibrationDisplay.from_predictions(labels, probs, n_bins=10)
+    disp.ax_.set_title("Reliability curve")
+    disp.figure_.tight_layout()
+    disp.figure_.savefig(plot_path)
+    plt.close(disp.figure_)
+    print(f"Brier score: {brier:.3f}")
+    return brier
+
+
+def main(args=None) -> None:
+    parser = argparse.ArgumentParser(description="Model calibration metrics")
+    parser.add_argument("--model-path", default="model.pt", type=Path)
+    parser.add_argument("--plot-path", default="calibration.png", type=Path)
+    parsed = parser.parse_args(args)
+    calibrate_model(parsed.model_path, parsed.plot_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,4 +22,7 @@ inputs.
 
 3. The script saves `model.pt` and exits with code `1` if ROC-AUC < 0.90.
 
+4. Run `python calibrate.py` to print the Brier score and save a
+   reliability plot for the saved model.
+
 Future docs will detail the dataset and training options once implemented.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,9 @@ CardioRisk-NN API
 .. automodule:: evaluate
    :members:
 
+.. automodule:: calibrate
+   :members:
+
 .. automodule:: model
    :members:
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -18,7 +18,10 @@ def evaluate(seed: int = 0) -> float:
 
 def load_data(batch_size: int = 64) -> DataLoader:
     """Load the Cleveland heart dataset as a DataLoader."""
-    df = pd.read_csv(Path("data") / "heart.csv")
+    df = pd.read_csv(Path("data") / "heart.csv", na_values="?")
+    df = df.fillna(df.mean(numeric_only=True))
+    df = df.astype(float)
+    df["target"] = (df["target"] > 0).astype(float)
     X = df.drop(columns=["target"]).to_numpy(dtype="float32")
     y = df["target"].to_numpy(dtype="float32")
     dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))

--- a/setup.sh
+++ b/setup.sh
@@ -6,4 +6,4 @@ set -e
 pip install --extra-index-url https://download.pytorch.org/whl/cpu torch==2.3.*
 
 # Core libraries
-pip install pandas scikit-learn
+pip install pandas scikit-learn matplotlib

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,23 @@
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import train  # noqa: E402
+import calibrate  # noqa: E402
+
+
+def test_calibration_runtime(tmp_path):
+    start = time.time()
+    model_path = tmp_path / "model.pt"
+    plot_path = tmp_path / "cal.png"
+
+    with pytest.raises(SystemExit):
+        train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
+    assert model_path.exists()
+
+    calibrate.main(["--model-path", str(model_path), "--plot-path", str(plot_path)])
+    assert plot_path.exists()
+    assert time.time() - start < 10


### PR DESCRIPTION
## Summary
- add `calibrate.py` with CLI for Brier score and reliability plot
- install matplotlib via `setup.sh`
- test calibration runtime
- document calibration script in README and Sphinx docs
- log work in NOTES and tick TODO
- fix evaluate loader to handle '?' values

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d86d46ed083259b930ffb40ba2903