### PR TITLE
Fix docs for 3‑epoch fast run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,6 @@ It always builds the Sphinx docs with `sphinx-build`.
 | `NOTES.md` | chronological engineering log |
 | `AGENTS.md` | *this* contributor guide |
 
-| `setup.sh` | dependency installer |
-
-| `.env` | runtime variables for the sandbox |
 | `setup.sh` | dependency installer (PyTorch & TensorFlow) |
 
 | `.github/workflows/ci.yml` | lints & tests in CI |

--- a/NOTES.md
+++ b/NOTES.md
@@ -92,7 +92,6 @@
   Tests cover fast model calibration. Updated README, Sphinx docs and
   setup.sh. Reason: implement optional calibration feature from TODO.
 
-
 - 2025-07-20: Removed unused `.env` file and cleaned docs.
   Reason: default epochs come from code; no env vars used.
   Updated README and AGENTS to stay consistent.
@@ -106,3 +105,7 @@
   Updated setup.sh to install TensorFlow and documented usage in README and
   overview. Sphinx docs now include `train_tf` module. Reason: implement
   stretch goal from TODO.
+
+- 2025-07-21: Updated README fast-mode docs to 3 epochs, removed `.env` entry
+  and cleaned AGENTS file roles. Ticked TODO item to mention the 3-epoch test.
+  Reason: keep documentation consistent with the code.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Keras variant runs similarly:
 python train_tf.py --seed 0
 ```
 
-Add `--fast` for a 10‑epoch demo and `--model-path` to set the output file.
+Add `--fast` for a 3‑epoch demo and `--model-path` to set the output file.
 `train.py` saves `model.pt` while `train_tf.py` defaults to `model_tf.h5`. Both
 exit with status 1 when ROC‑AUC is below 0.90.
 
@@ -79,13 +79,10 @@ AGENTS.md             ← contributor & CI guidelines
 See [docs/overview.md](docs/overview.md) for a sketch of the MLP and
 the training workflow.
 
-
-
 ### `.env` file
 
-This file is currently unused and only kept as a placeholder for potential
-environment variables.
-All scripts are CPU-only and keep RAM use < 100 MB.
+No `.env` file is provided because the scripts run without extra
+environment variables. All jobs stay CPU‑only and use under 100 MB of RAM.
 
 ### Docker usage
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@
 ## 2. Testing
 
 - [x] `tests/test_smoke.py` – import modules
-- [x] `tests/test_train_fast.py` – 10-epoch fast run under 20 s
+- [x] `tests/test_train_fast.py` – 3-epoch fast run under 20 s
 - [x] `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
 
 ## 3. Documentation


### PR DESCRIPTION
## Summary
- clarify that `--fast` does only 3 epochs
- remove unused `.env` references
- keep AGENTS table accurate
- update TODO and NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_684e9e06bd3083258a0262dfc13f3c0a