### PR TITLE
Fix flake8 line length in calibrate tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -109,3 +109,5 @@
 - 2025-07-21: Updated README fast-mode docs to 3 epochs, removed `.env` entry
   and cleaned AGENTS file roles. Ticked TODO item to mention the 3-epoch test.
   Reason: keep documentation consistent with the code.
+- 2025-07-22: Wrapped `calibrate.main` call in tests to satisfy flake8 line
+  length. Installed TensorFlow so tests run. Reason: fix style error.

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -18,6 +18,12 @@ def test_calibration_runtime(tmp_path):
         train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
     assert model_path.exists()
 
-    calibrate.main(["--model-path", str(model_path), "--plot-path", str(plot_path)])
+    args = [
+        "--model-path",
+        str(model_path),
+        "--plot-path",
+        str(plot_path),
+    ]
+    calibrate.main(args)
     assert plot_path.exists()
     assert time.time() - start < 10


### PR DESCRIPTION
## Summary
- wrap calibrate.main call to fit flake8 line length
- log the change in NOTES

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fce6c958c832582f4cf6cd3313025