### PR TITLE
Add requirements file and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.txt
           pip install black flake8 pytest sphinx
+          bash setup.sh
 
       - name: Install markdownlint
         run: npm install -g markdownlint-cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ It always builds the Sphinx docs with `sphinx-build`.
 ## 2. Workflow
 
 1. Run `./setup.sh` once after cloning to install the Python deps
-   (PyTorch, TensorFlow, pandas, scikit-learn).
+   (PyTorch, TensorFlow, pandas, scikit-learn). CI installs the same
+   packages with `pip install -r requirements.txt` and then calls
+   `bash setup.sh` for parity.
 2. *(Optional)* build the Docker image with `docker build -t cardiorisk .`.
 3. Branch off **main** – name `feat/<topic>`.
 4. Keep edits to *distinct* source files where possible.

--- a/NOTES.md
+++ b/NOTES.md
@@ -109,3 +109,5 @@
 - 2025-07-21: Updated README fast-mode docs to 3 epochs, removed `.env` entry
   and cleaned AGENTS file roles. Ticked TODO item to mention the 3-epoch test.
   Reason: keep documentation consistent with the code.
+- 2025-07-22: Added requirements.txt and changed CI to install from it and run
+  setup.sh. Updated AGENTS accordingly. Reason: keep installs consistent.

--- a/TODO.md
+++ b/TODO.md
@@ -42,3 +42,4 @@
 - [x] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [x] Dockerfile for exact reproducibility
 - [x] Switch `train.py` to a PyTorch loop using `build_mlp`
+- [x] Add requirements.txt and use it in CI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+tensorflow
+pandas
+scikit-learn
+matplotlib


### PR DESCRIPTION
## Summary
- list core Python packages in `requirements.txt`
- install them in CI via `pip install -r requirements.txt`
- run `bash setup.sh` during CI setup
- document CI install step in `AGENTS.md`
- record change in `NOTES.md` and tick TODO

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fce72dad88325bc10b1ae92c5af26