### PR TITLE
Refactor training and calibration helpers

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+codex.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ It always builds the Sphinx docs with `sphinx-build`.
 3. Branch off **main** – name `feat/<topic>`.
 4. Keep edits to *distinct* source files where possible.
 5. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
-6. Run `npx markdownlint-cli '**/*.md'` before pushing.
+6. Run `npx markdownlint-cli '**/*.md'` before pushing. The file `codex.md`
+   is excluded via `.markdownlintignore`.
 7. If you change tests, linters, or build scripts, also update **AGENTS.md**.
 8. A task is *done* only when CI is **all green**.
    Docs-only commits run only the markdown jobs; code commits run the full test suite.

--- a/NOTES.md
+++ b/NOTES.md
@@ -109,3 +109,6 @@
 - 2025-07-21: Updated README fast-mode docs to 3 epochs, removed `.env` entry
   and cleaned AGENTS file roles. Ticked TODO item to mention the 3-epoch test.
   Reason: keep documentation consistent with the code.
+- 2025-07-21: Moved training loop to `_train_epoch` and split plotting helper
+  in `calibrate.py`. Added `.markdownlintignore` for codex.md. Reason: refactor
+  for clarity and keep linters green.

--- a/TODO.md
+++ b/TODO.md
@@ -42,3 +42,4 @@
 - [x] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
 - [x] Dockerfile for exact reproducibility
 - [x] Switch `train.py` to a PyTorch loop using `build_mlp`
+- [x] Refactor training and calibration helpers for clarity

--- a/calibrate.py
+++ b/calibrate.py
@@ -11,6 +11,17 @@ import matplotlib.pyplot as plt
 from evaluate import load_data
 
 
+def _save_reliability_plot(
+    labels: list[float], probs: list[float], plot_path: Path
+) -> None:
+    """Save calibration curve."""
+    disp = CalibrationDisplay.from_predictions(labels, probs, n_bins=10)
+    disp.ax_.set_title("Reliability curve")
+    disp.figure_.tight_layout()
+    disp.figure_.savefig(plot_path)
+    plt.close(disp.figure_)
+
+
 def calibrate_model(model_path: Path, plot_path: Path) -> float:
     """Compute Brier score and save reliability plot."""
     loader = load_data()
@@ -26,11 +37,7 @@ def calibrate_model(model_path: Path, plot_path: Path) -> float:
             labels.extend(target.tolist())
 
     brier = brier_score_loss(labels, probs)
-    disp = CalibrationDisplay.from_predictions(labels, probs, n_bins=10)
-    disp.ax_.set_title("Reliability curve")
-    disp.figure_.tight_layout()
-    disp.figure_.savefig(plot_path)
-    plt.close(disp.figure_)
+    _save_reliability_plot(labels, probs, plot_path)
     print(f"Brier score: {brier:.3f}")
     return brier
 

--- a/train.py
+++ b/train.py
@@ -21,6 +21,22 @@ def _load_split(seed: int):
     return x_train, x_test, y_train, y_test
 
 
+def _train_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer,
+):
+    """Train one epoch."""
+    model.train()
+    for features, target in loader:
+        optimizer.zero_grad()
+        out = model(features)
+        loss = criterion(out, target)
+        loss.backward()
+        optimizer.step()
+
+
 def train_model(
     fast: bool,
     seed: int,
@@ -39,12 +55,7 @@ def train_model(
     )
     epochs = 3 if fast else 200
     for _ in range(epochs):
-        for features, target in loader:
-            optimizer.zero_grad()
-            out = model(features)
-            loss = criterion(out, target)
-            loss.backward()
-            optimizer.step()
+        _train_epoch(model, loader, criterion, optimizer)
 
     if model_path:
         torch.save(model, model_path)


### PR DESCRIPTION
## Summary
- move train loop to `_train_epoch`
- split plot save logic to `_save_reliability_plot`
- note markdownlint ignore for codex.md
- log work in NOTES and roadmap in TODO

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fce7789c483258685074a7865cea7