### PR TITLE
Fix test_calibrate style gap

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -126,3 +126,5 @@
 
 - 2025-07-22: Wrapped `calibrate.main` call in tests to satisfy flake8 line
   length. Installed TensorFlow so tests run. Reason: fix style error.
+
+- 2025-07-23: Reduced blank lines before args in tests/test_calibrate.py and ran black/flake8. Reason: fix style per guidelines.

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -18,7 +18,6 @@ def test_calibration_runtime(tmp_path):
         train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
     assert model_path.exists()
 
-
     args = [
         "--model-path",
         str(model_path),


### PR DESCRIPTION
## Summary
- keep just one blank line before the args list in `tests/test_calibrate.py`
- log the change in `NOTES.md`

## Testing
- `flake8`
- `black --check --line-length 88 tests/test_calibrate.py`
- `pytest -q`
- `npx markdownlint-cli '**/*.md'` *(fails: needs network access)*

------
https://chatgpt.com/codex/tasks/task_e_684fd58355308325a91ec84b819af16e