### PR TITLE
Refactor train scripts helpers

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -126,3 +126,8 @@
 
 - 2025-07-22: Wrapped `calibrate.main` call in tests to satisfy flake8 line
   length. Installed TensorFlow so tests run. Reason: fix style error.
+
+- 2025-07-23: Refactored `train.py` and `train_tf.py` to move loader and model
+  setup into helper functions. `train_model` bodies now stay under 20 lines.
+  Reason: meet refactor request and style limits; decisions: created
+  `_init_model`, `_make_loader`, and `_build_model` helpers.

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -18,7 +18,6 @@ def test_calibration_runtime(tmp_path):
         train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
     assert model_path.exists()
 
-
     args = [
         "--model-path",
         str(model_path),

--- a/train.py
+++ b/train.py
@@ -37,6 +37,20 @@ def _train_epoch(
         optimizer.step()
 
 
+def _init_model(n_features: int):
+    """Return model, criterion and optimizer."""
+    model = build_mlp(n_features)
+    criterion = nn.BCEWithLogitsLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+    return model, criterion, optimizer
+
+
+def _make_loader(x_train: torch.Tensor, y_train: torch.Tensor) -> DataLoader:
+    """Return a training DataLoader."""
+    dataset = TensorDataset(x_train, y_train.unsqueeze(1))
+    return DataLoader(dataset, batch_size=64, shuffle=True)
+
+
 def train_model(
     fast: bool,
     seed: int,
@@ -45,14 +59,8 @@ def train_model(
     """Train the MLP and return ROC-AUC."""
     torch.manual_seed(seed)
     x_train, x_test, y_train, y_test = _load_split(seed)
-    model = build_mlp(x_train.shape[1])
-    criterion = nn.BCEWithLogitsLoss()
-    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    loader = DataLoader(
-        TensorDataset(x_train, y_train.unsqueeze(1)),
-        batch_size=64,
-        shuffle=True,
-    )
+    model, criterion, optimizer = _init_model(x_train.shape[1])
+    loader = _make_loader(x_train, y_train)
     epochs = 3 if fast else 200
     for _ in range(epochs):
         _train_epoch(model, loader, criterion, optimizer)

--- a/train_tf.py
+++ b/train_tf.py
@@ -24,6 +24,20 @@ def _load_split(seed: int):
     return x_train, x_test, y_train, y_test
 
 
+def _build_model(input_dim: int) -> tf.keras.Model:
+    """Return a compiled Keras MLP."""
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(shape=(input_dim,)),
+            tf.keras.layers.Dense(32, activation="relu"),
+            tf.keras.layers.Dense(16, activation="relu"),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
+    model.compile(optimizer="adam", loss="binary_crossentropy")
+    return model
+
+
 def train_model(
     fast: bool,
     seed: int,
@@ -33,15 +47,7 @@ def train_model(
     np.random.seed(seed)
     tf.random.set_seed(seed)
     x_train, x_test, y_train, y_test = _load_split(seed)
-    model = tf.keras.Sequential(
-        [
-            tf.keras.layers.Input(shape=(x_train.shape[1],)),
-            tf.keras.layers.Dense(32, activation="relu"),
-            tf.keras.layers.Dense(16, activation="relu"),
-            tf.keras.layers.Dense(1, activation="sigmoid"),
-        ]
-    )
-    model.compile(optimizer="adam", loss="binary_crossentropy")
+    model = _build_model(x_train.shape[1])
     epochs = 3 if fast else 200
     model.fit(x_train, y_train, epochs=epochs, batch_size=64, verbose=0)
     if model_path:


### PR DESCRIPTION
## Summary
- extract model/optimizer creation & dataloader setup in `train.py`
- add Keras model helper in `train_tf.py`
- keep `train_model` functions short
- document refactor

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd58b00748325ad26c9ec9cfcbbec