### PR TITLE
Update pinned requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ It always builds the Sphinx docs with `sphinx-build`.
 1. Run `./setup.sh` once after cloning to install the Python deps
    (PyTorch, TensorFlow, pandas, scikit-learn). CI installs the same
    packages with `pip install -r requirements.txt` and then calls
-   `bash setup.sh` for parity.
+   `bash setup.sh` for parity. Keep the version pins in
+   `requirements.txt` mirrored in `setup.sh` so local installs match CI.
 2. *(Optional)* build the Docker image with `docker build -t cardiorisk .`.
 3. Branch off **main** – name `feat/<topic>`.
 4. Keep edits to *distinct* source files where possible.

--- a/NOTES.md
+++ b/NOTES.md
@@ -126,3 +126,6 @@
 
 - 2025-07-22: Wrapped `calibrate.main` call in tests to satisfy flake8 line
   length. Installed TensorFlow so tests run. Reason: fix style error.
+- 2025-06-16: Pinned torch and tensorflow in requirements.txt to match
+  setup.sh and added note in AGENTS. Reason: keep installs reproducible
+  across devs and CI.

--- a/TODO.md
+++ b/TODO.md
@@ -46,3 +46,6 @@
 - [x] Switch `train.py` to a PyTorch loop using `build_mlp`
 - [x] Refactor training and calibration helpers for clarity
 - [x] Add requirements.txt and use it in CI
+
+- [x] Pin torch==2.3.\* and tensorflow==2.19.\* in requirements.txt.
+  Document keeping pins in sync with `setup.sh` in AGENTS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch
-tensorflow
+torch==2.3.*
+tensorflow==2.19.*
 pandas
 scikit-learn
 matplotlib

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -18,7 +18,6 @@ def test_calibration_runtime(tmp_path):
         train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
     assert model_path.exists()
 
-
     args = [
         "--model-path",
         str(model_path),


### PR DESCRIPTION
## Summary
- pin `torch` and `tensorflow` versions in requirements.txt
- remind contributors to keep setup.sh and requirements pins identical
- log the change in NOTES and mark TODO done
- cleanup test file with black

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `black --check .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fd5925fd08325a4a61aa59b4891c4