### PR TITLE
Update AGENTS for markdownlint usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ It always builds the Sphinx docs with `sphinx-build`.
 * 4‑space indent, `black` line length = 88.
 * Validate inputs early; raise on bad data.
 * End every file with a newline; keep Markdown lines ≤ 80 chars.
+* Run `npx --yes markdownlint-cli '**/*.md'` (or install globally) to ensure
+  Markdown lines stay within 80 characters. This catches issues before pushing.
 
 ## 4. Documentation style
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -136,4 +136,8 @@
   Reason: meet refactor request and style limits; decisions: created
   `_init_model`, `_make_loader`, and `_build_model` helpers.
 
-- 2025-07-23: Reduced blank lines before args in tests/test_calibrate.py and ran black/flake8. Reason: fix style per guidelines.
+- 2025-07-23: Reduced blank lines before args in tests/test_calibrate.py
+  and ran black/flake8. Reason: fix style per guidelines.
+
+- 2025-06-16: Documented `npx --yes markdownlint-cli` in AGENTS to catch
+  markdown line length issues before pushing.


### PR DESCRIPTION
## Summary
- document using `npx --yes markdownlint-cli` to catch Markdown line-length issues
- note it in engineering log

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `sphinx-build -b html docs/source docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_684fdd045b1c8325afcef1eb17b693a3