### PR TITLE
docs: wrap long NOTES entry

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -136,4 +136,6 @@
   Reason: meet refactor request and style limits; decisions: created
   `_init_model`, `_make_loader`, and `_build_model` helpers.
 
-- 2025-07-23: Reduced blank lines before args in tests/test_calibrate.py and ran black/flake8. Reason: fix style per guidelines.
+- 2025-07-23: Reduced blank lines before args in tests/test_calibrate.py
+  and ran black/flake8. Reason: fix style per guidelines.
+- 2025-07-24: Fixed NOTES.md line length to satisfy markdownlint.

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@
 - [x] Clarify in README that `evaluate.py` loads `model.pt` by default and that
   `evaluate()` runs the short training used in tests
 - [x] Add `.markdownlint.json` ignoring `codex.md`
+- [x] Wrap long entry in NOTES.md to satisfy markdownlint
 
 ## 4. Stretch goals
 


### PR DESCRIPTION
## Summary
- split a long bullet in NOTES.md into short lines
- log the cleanup with a new dated bullet
- mark the line-wrapping task as done in TODO

## Testing
- `npx markdownlint-cli '**/*.md'`
- `yes | npx markdown-link-check README.md`

------
https://chatgpt.com/codex/tasks/task_e_684fdcff39008325ab8eb13a6c07041f