### PR TITLE
Add early stopping with validation split

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -143,3 +143,8 @@
 
 - 2025-06-16: Documented `npx --yes markdownlint-cli` in AGENTS to catch
   markdown line length issues before pushing.
+
+- 2025-07-31: Added early stopping with validation split in `train.py`. Updated
+  README, docs and tests accordingly. Reason: expose better training behaviour.
+  Decisions: patience fixed at five epochs and max epochs increased to 20 in
+  fast mode.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The Keras variant runs similarly:
 python train_tf.py --seed 0
 ```
 
-Add `--fast` for a 3‑epoch demo and `--model-path` to set the output file.
+Add `--fast` for a quick demo with early stopping (patience 5, max 20 epochs)
+and `--model-path` to set the output file.
 `train.py` saves `model.pt` while `train_tf.py` defaults to `model_tf.h5`. Both
 exit with status 1 when ROC‑AUC is below 0.90.
 

--- a/TODO.md
+++ b/TODO.md
@@ -50,3 +50,5 @@
 
 - [x] Pin torch==2.3.\* and tensorflow==2.19.\* in requirements.txt.
   Document keeping pins in sync with `setup.sh` in AGENTS.
+
+- [ ] Expose CLI flag for early stopping patience.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -21,10 +21,13 @@ inputs.
 2. Run `python train.py --fast --seed 0` for a PyTorch demo or
    `python train_tf.py --fast --seed 0` for the Keras version.
 
-3. The scripts save `model.pt` or `model_tf.h5` and exit with code `1` if
-   ROC-AUC < 0.90.
+3. The scripts split the data 80/20 for validation. Training stops when the
+   validation ROC-AUC has not improved for 5 epochs.
 
-4. Run `python calibrate.py` to print the Brier score and save a
+4. Models are saved as `model.pt` or `model_tf.h5` and the scripts exit with
+   code `1` if ROC-AUC < 0.90.
+
+5. Run `python calibrate.py` to print the Brier score and save a
    reliability plot for the saved model.
 
 Future docs will detail the dataset and training options once implemented.

--- a/tests/test_train_fast.py
+++ b/tests/test_train_fast.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import train  # noqa: E402
 
 
-def test_fast_training_runs_under_20s():
+def test_fast_training_runs_under_20s(capsys):
     start = time.time()
     model_file = Path("model.pt")
     if model_file.exists():
@@ -16,6 +16,8 @@ def test_fast_training_runs_under_20s():
     with pytest.raises(SystemExit) as exc:
         train.main(["--fast", "--seed", "0"])
     assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Early stopping" in out
     assert time.time() - start < 20
     assert model_file.exists()
     model_file.unlink()

--- a/train.py
+++ b/train.py
@@ -5,7 +5,7 @@ import sys
 from sklearn.metrics import roc_auc_score
 import torch
 from torch import nn
-from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data import DataLoader, TensorDataset, random_split
 
 from data_utils import load_data
 from model import build_mlp
@@ -45,10 +45,41 @@ def _init_model(n_features: int):
     return model, criterion, optimizer
 
 
-def _make_loader(x_train: torch.Tensor, y_train: torch.Tensor) -> DataLoader:
-    """Return a training DataLoader."""
-    dataset = TensorDataset(x_train, y_train.unsqueeze(1))
-    return DataLoader(dataset, batch_size=64, shuffle=True)
+def _make_loader(
+    x: torch.Tensor, y: torch.Tensor, shuffle: bool = True
+) -> DataLoader:
+    """Return a DataLoader for the given tensors."""
+    dataset = TensorDataset(x, y.unsqueeze(1))
+    return DataLoader(dataset, batch_size=64, shuffle=shuffle)
+
+
+def _split_train_valid(
+    x_train: torch.Tensor, y_train: torch.Tensor, seed: int
+) -> tuple[DataLoader, DataLoader]:
+    """Return loaders for the train/validation split."""
+    val_size = max(1, len(x_train) // 5)
+    train_size = len(x_train) - val_size
+    gen = torch.Generator().manual_seed(seed)
+    dataset = TensorDataset(x_train, y_train)
+    train_ds, val_ds = random_split(dataset, [train_size, val_size], generator=gen)
+    return (
+        DataLoader(train_ds, batch_size=64, shuffle=True),
+        DataLoader(val_ds, batch_size=64, shuffle=False),
+    )
+
+
+def _calc_auc(model: nn.Module, loader: DataLoader) -> float:
+    """Return ROC-AUC for the model on the loader."""
+    model.eval()
+    preds = []
+    targets = []
+    with torch.no_grad():
+        for features, target in loader:
+            preds.append(model(features).squeeze())
+            targets.append(target.squeeze())
+    preds = torch.cat(preds).numpy()
+    targets = torch.cat(targets).numpy()
+    return roc_auc_score(targets, preds)
 
 
 def train_model(
@@ -60,18 +91,28 @@ def train_model(
     torch.manual_seed(seed)
     x_train, x_test, y_train, y_test = _load_split(seed)
     model, criterion, optimizer = _init_model(x_train.shape[1])
-    loader = _make_loader(x_train, y_train)
-    epochs = 3 if fast else 200
-    for _ in range(epochs):
-        _train_epoch(model, loader, criterion, optimizer)
+    train_loader, val_loader = _split_train_valid(x_train, y_train, seed)
+    test_loader = _make_loader(x_test, y_test, shuffle=False)
+    epochs = 20 if fast else 200
+    best_auc = 0.0
+    stale = 0
+    for epoch in range(epochs):
+        _train_epoch(model, train_loader, criterion, optimizer)
+        val_auc = _calc_auc(model, val_loader)
+        if val_auc > best_auc:
+            best_auc = val_auc
+            stale = 0
+        else:
+            stale += 1
+        if stale >= 5:
+            print(f"Early stopping at epoch {epoch + 1}")
+            break
 
     if model_path:
         torch.save(model, model_path)
 
-    model.eval()
-    with torch.no_grad():
-        preds = model(x_test).squeeze()
-    return roc_auc_score(y_test.numpy(), preds.numpy())
+    auc = _calc_auc(model, test_loader)
+    return auc
 
 
 def main(args=None):


### PR DESCRIPTION
## Summary
- implement validation split and 5-epoch early stopping in `train.py`
- expect "Early stopping" message in fast training test
- document early stopping in README and docs
- log change in NOTES and add TODO item

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -q` *(fails: ImportError: libscipy_openblas-68440149.so)*

------
https://chatgpt.com/codex/tasks/task_e_684fe20c482883258fc34ed5c8653660