### PR TITLE
docs: tidy overview bullet list

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -152,3 +152,7 @@
   README, docs and tests accordingly. Reason: expose better training behaviour.
   Decisions: patience fixed at five epochs and max epochs increased to 20 in
   fast mode.
+
+- 2025-06-16: Cleaned docs/overview bullet list.
+  Combined model saving with exit code and mentioned early stop once.
+  Reason: tidy docs.

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,7 @@
   `evaluate()` runs the short training used in tests
 - [x] Add `.markdownlint.json` ignoring `codex.md`
 - [x] Wrap long entry in NOTES.md to satisfy markdownlint
+- [x] Consolidate workflow steps in `docs/overview.md`
 
 ## 4. Stretch goals
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,22 +18,12 @@ inputs.
 
 1. Install dependencies with `bash setup.sh`.
 
-2. Run `python train.py --fast --seed 0` for a PyTorch demo or
-   `python train_tf.py --fast --seed 0` for the Keras version.
+2. Run `python train.py --fast --seed 0` or `python train_tf.py --fast`.
 
-3. The scripts save `model.pt` or `model_tf.h5` and exit with code `1` if
-   ROC-AUC < 0.90.
-   The Keras training uses early stopping with patience 5 so long runs finish
-   early when the loss stops improving.
+3. Data split 80/20; training stops after 5 stale ROC-AUC epochs.
 
-3. The scripts split the data 80/20 for validation. Training stops when the
-   validation ROC-AUC has not improved for 5 epochs.
+4. Models saved as `model.pt` or `model_tf.h5`; scripts exit 1 if AUC < 0.90.
 
-
-4. Models are saved as `model.pt` or `model_tf.h5` and the scripts exit with
-   code `1` if ROC-AUC < 0.90.
-
-5. Run `python calibrate.py` to print the Brier score and save a
-   reliability plot for the saved model.
+5. Run `python calibrate.py` to save a reliability plot and Brier score.
 
 Future docs will detail the dataset and training options once implemented.


### PR DESCRIPTION
## Summary
- clarify workflow in `docs/overview.md`
- log cleanup in NOTES
- mark roadmap item done for overview bullets

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684fe656282c83258c2de025a608ce0f