### PR TITLE
Call train_model in tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -168,3 +168,5 @@
   Adjusted fast-mode learning rate so test seed 0 stays below the 0.90 AUC
   threshold. Reason: loss function expected `[batch,1]` targets and tests rely on
   failing fast mode.
+- 2025-08-02: Updated tests to call `train.train_model` directly, capturing
+  early-stopping output. Reason: follow refactor removing CLI dependency.

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,7 @@
 - [x] `tests/test_train_fast.py` – 3-epoch fast run under 20 s
 - [x] `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
 - [x] Add test for `evaluate_saved_model` ensuring ROC-AUC ≥ 0.90
+- [x] Update tests to call `train.train_model` directly after CLI refactor
 
 ## 3. Documentation
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -12,7 +12,7 @@ def test_calibration_runtime(tmp_path):
     model_path = tmp_path / "model.pt"
     plot_path = tmp_path / "cal.png"
 
-    train.main(["--fast", "--seed", "0", "--model-path", str(model_path)])
+    train.train_model(True, seed=0, model_path=str(model_path))
 
     assert model_path.exists()
 

--- a/tests/test_train_fast.py
+++ b/tests/test_train_fast.py
@@ -12,7 +12,7 @@ def test_fast_training_runs_under_20s(capsys):
     if model_file.exists():
         model_file.unlink()
 
-    train.main(["--fast", "--seed", "0"])
+    train.train_model(True, seed=0, model_path="model.pt")
 
     out = capsys.readouterr().out
     assert "Early stopping" in out


### PR DESCRIPTION
## Summary
- update test_train_fast to call train.train_model
- capture early stopping message from stdout
- update calibration test to use train_model
- record change in NOTES and TODO

## Testing
- `flake8 tests/test_calibrate.py tests/test_train_fast.py`
- `pytest -q`
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684ff27bcc788325a13e463bcd39f37e