### PR TITLE
Document CLI exit behaviour in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ It always builds the Sphinx docs with `sphinx-build`.
 * End every file with a newline; keep Markdown lines ≤ 80 chars.
 * Run `npx --yes markdownlint-cli '**/*.md'` (or install globally) to ensure
   Markdown lines stay within 80 characters. This catches issues before pushing.
+* `train.py` and `train_tf.py` exit with code 1 when ROC-AUC < 0.90.
+  In tests, call `train.train_model()` or `train_tf.train_model()`
+  to avoid exits.
 
 ## 4. Documentation style
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -168,3 +168,6 @@
   Adjusted fast-mode learning rate so test seed 0 stays below the 0.90 AUC
   threshold. Reason: loss function expected `[batch,1]` targets and tests rely on
   failing fast mode.
+- 2025-08-02: Documented exit code rule in AGENTS and noted tests should use
+  train.train_model() or train_tf.train_model() to avoid SystemExit. CI
+  failed when tests called main(); fixed by calling helpers.

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,8 @@
 - [x] `tests/test_train_fast.py` – 3-epoch fast run under 20 s
 - [x] `tests/test_metrics.py` – check AUC ≥ 0.85 on fixed seed
 - [x] Add test for `evaluate_saved_model` ensuring ROC-AUC ≥ 0.90
+- [x] Adapt tests to call `train.train_model()` or `train_tf.train_model()`
+  to avoid exit code failures when AUC < 0.90
 
 ## 3. Documentation
 


### PR DESCRIPTION
## Summary
- clarify exit code rule in AGENTS and point tests to helper functions
- record the CI failure fix in NOTES
- log the test adaptation in TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_684ff27dce7c8325bcdd799ec3551e48