### PR TITLE
Docs: update TODO for backend entry

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -175,3 +175,6 @@
 
 - 2025-08-02: Updated tests to call `train.train_model` directly, capturing
   early-stopping output. Reason: follow refactor removing CLI dependency.
+- 2025-08-03: Clarified TODO TensorFlow backend entry and noted train.py early
+  stopping bullet. Reason: keep TODO in sync with code; decisions: CLI has no
+  --backend flag.

--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@
 ## 4. Stretch goals
 
 - [x] Optional calibration script & reliability plot
-- [x] TensorFlow backend (`train_tf.py`, CLI `--backend tf`)
+- [x] TensorFlow backend provided by `train_tf.py` script (no `--backend` flag)
 - [x] Dockerfile for exact reproducibility
 - [x] Switch `train.py` to a PyTorch loop using `build_mlp`
 - [x] Refactor training and calibration helpers for clarity
@@ -55,4 +55,5 @@
   Document keeping pins in sync with `setup.sh` in AGENTS.
 - [x] Add early stopping to Keras trainer with patience 5 and update tests
   and docs.
+- [x] Added early stopping to `train.py` with fixed patience 5 (see NOTES 2025-07-31).
 - [x] Expose CLI flag for early stopping patience.


### PR DESCRIPTION
## Summary
- clarify that train_tf.py provides the TensorFlow backend
- note that train.py gained fixed patience early stopping
- log TODO updates in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff61e3ffc83259392923ef21ae82b