### PR TITLE
Add logistic regression baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ It always builds the Sphinx docs with `sphinx-build`.
 * `train.py` and `train_tf.py` exit with code 1 when ROC-AUC < 0.90.
   In tests, call `train.train_model()` or `train_tf.train_model()`
   to avoid exits.
+* `baseline.py` exits with code 1 when ROC-AUC < 0.84.
+  Call `baseline.train_model()` in tests to avoid the exit.
 
 ## 4. Documentation style
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -187,3 +187,7 @@
 - 2025-08-04: Added cross_validate.py for k-fold evaluation with tests and docs.
   Reason: expose simple validation helper. Decisions: use seeded splits calling
   train.train_model.
+- 2025-08-05: Added baseline.py logistic regression with CLI flags `--seed` and
+  `--model-path`. Created test_baseline.py and documented usage in README and
+  docs/overview. Reason: provide a simple reference model. Decisions: exit with
+  code 1 when AUC < 0.84 to mirror train.py behaviour.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The Keras variant runs similarly:
 python train_tf.py --seed 0
 ```
 
+The logistic-regression baseline runs as:
+
+```bash
+python baseline.py --seed 0
+```
+
 Add `--fast` for a quick demo with early stopping. Use `--patience N` (default
 5, max 20 epochs in fast mode) and `--model-path` to set the output file.
 `train.py` saves `model.pt` while `train_tf.py` defaults to `model_tf.h5`. Both
@@ -74,6 +80,7 @@ train_tf.py           ← Keras training script
 evaluate.py           ← model metrics helper
 calibrate.py          ← reliability plot helper
 cross_validate.py     ← k-fold validation helper
+baseline.py          ← logistic-regression baseline
 
 README.md             ← you are here
 TODO.md               ← roadmap tasks

--- a/TODO.md
+++ b/TODO.md
@@ -59,3 +59,4 @@
 - [x] Added early stopping to `train.py` with fixed patience 5 (see NOTES 2025-07-31).
 - [x] Expose CLI flag for early stopping patience.
 - [x] Add cross_validate.py helper and tests.
+- [x] Add baseline.py with logistic regression and tests.

--- a/baseline.py
+++ b/baseline.py
@@ -1,0 +1,49 @@
+"""Logistic regression baseline for CardioRisk-NN."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Tuple
+
+import joblib
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.preprocessing import StandardScaler
+
+from data_utils import load_data
+
+
+def _load_scaled(seed: int) -> Tuple:
+    """Return scaled train/test numpy arrays."""
+    x_train, x_test, y_train, y_test = load_data(random_state=seed)
+    scaler = StandardScaler().fit(x_train)
+    x_train = scaler.transform(x_train)
+    x_test = scaler.transform(x_test)
+    return x_train, x_test, y_train.numpy(), y_test.numpy(), scaler
+
+
+def train_model(seed: int, model_path: str | None = "baseline.pkl") -> float:
+    """Train logistic regression and return ROC-AUC."""
+    x_train, x_test, y_train, y_test, scaler = _load_scaled(seed)
+    model = LogisticRegression(max_iter=1000)
+    model.fit(x_train, y_train)
+    if model_path:
+        joblib.dump((scaler, model), model_path)
+    preds = model.predict_proba(x_test)[:, 1]
+    return float(roc_auc_score(y_test, preds))
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Train logistic regression")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--model-path", default="baseline.pkl")
+    parsed = parser.parse_args(args)
+    auc = train_model(parsed.seed, parsed.model_path)
+    print(f"ROC-AUC: {auc:.3f}")
+    if auc < 0.84:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,4 +29,7 @@ inputs.
 
 6. Run `python cross_validate.py --folds 5` for a quick k-fold score.
 
+7. Run `python baseline.py --seed 0` to train a logistic-regression
+   baseline and save `baseline.pkl`.
+
 Future docs will detail the dataset and training options once implemented.

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import baseline  # noqa: E402
+
+
+def test_baseline_auc(tmp_path):
+    model_path = tmp_path / "baseline.pkl"
+    auc = baseline.train_model(seed=0, model_path=str(model_path))
+    assert auc >= 0.84
+    assert model_path.exists()


### PR DESCRIPTION
## Summary
- add `baseline.py` for logistic-regression training
- create `test_baseline.py` checking ROC-AUC >= 0.84
- document baseline usage in README and docs
- update AGENTS, NOTES and TODO

## Testing
- `black baseline.py tests/test_baseline.py`
- `flake8`
- `pytest -q`
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_685004c8c7b883258eca55969c744c09