### PR TITLE
Add backend option to cross_validate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -187,3 +187,8 @@
 - 2025-08-04: Added cross_validate.py for k-fold evaluation with tests and docs.
   Reason: expose simple validation helper. Decisions: use seeded splits calling
   train.train_model.
+
+- 2025-08-05: Added `--backend {torch,tf}` option to cross_validate.py so users
+  can validate with the Keras trainer. Created new test_cross_validate_tf to
+  cover the TensorFlow path and updated README and docs. Reason: support
+  optional TensorFlow workflow.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ argument and prints ROC‑AUC. The module's `evaluate()` function (not the CLI)
 performs a short training run used in the tests.
 `calibrate.py` reports the Brier score and saves a reliability plot image for
 any saved model.
-`cross_validate.py` runs five quick training runs by default and prints the
-mean ROC-AUC.
+`cross_validate.py` runs several quick training runs and accepts a
+`--backend {torch,tf}` flag to choose which trainer to use. It prints the mean
+ROC-AUC over the folds.
 
 Repository layout:
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,3 +59,5 @@
 - [x] Added early stopping to `train.py` with fixed patience 5 (see NOTES 2025-07-31).
 - [x] Expose CLI flag for early stopping patience.
 - [x] Add cross_validate.py helper and tests.
+- [x] Optional `--backend` flag in cross_validate.py to choose PyTorch or
+  TensorFlow backend and tests for the TensorFlow path.

--- a/cross_validate.py
+++ b/cross_validate.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import argparse
 
 import train
+import train_tf
 
 
-def cross_validate(folds: int = 5) -> float:
+def cross_validate(folds: int = 5, backend: str = "torch") -> float:
     """Return mean ROC-AUC over several random splits."""
-    aucs = []
+    aucs: list[float] = []
     for seed in range(folds):
-        auc = train.train_model(True, seed=seed, model_path=None)
+        if backend == "torch":
+            auc = train.train_model(True, seed=seed, model_path=None)
+        else:
+            auc = train_tf.train_model(True, seed=seed, model_path=None)[0]
         aucs.append(auc)
     return float(sum(aucs) / len(aucs))
 
@@ -19,8 +23,14 @@ def cross_validate(folds: int = 5) -> float:
 def main(args: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run k-fold cross validation")
     parser.add_argument("--folds", type=int, default=5)
+    parser.add_argument(
+        "--backend",
+        choices=["torch", "tf"],
+        default="torch",
+        help="training backend",
+    )
     parsed = parser.parse_args(args)
-    mean_auc = cross_validate(parsed.folds)
+    mean_auc = cross_validate(parsed.folds, backend=parsed.backend)
     print(f"Mean ROC-AUC: {mean_auc:.3f}")
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -27,6 +27,7 @@ inputs.
 
 5. Run `python calibrate.py` to save a reliability plot and Brier score.
 
-6. Run `python cross_validate.py --folds 5` for a quick k-fold score.
+6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
+   quick k-fold score.
 
 Future docs will detail the dataset and training options once implemented.

--- a/tests/test_cross_validate_tf.py
+++ b/tests/test_cross_validate_tf.py
@@ -1,0 +1,13 @@
+import time
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cross_validate  # noqa: E402
+
+
+def test_cross_validation_tf_runs_quickly():
+    start = time.time()
+    mean_auc = cross_validate.cross_validate(folds=3, backend="tf")
+    assert mean_auc >= 0.85
+    assert time.time() - start < 40


### PR DESCRIPTION
## Summary
- enable TensorFlow backend with `--backend {torch,tf}`
- test TensorFlow cross-validation
- document the new flag in README and overview
- log the change in NOTES and TODO

## Testing
- `npx markdownlint-cli '**/*.md'` *(failed: npm error)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_685004c9aba48325961b50ae0b65e9d1