### PR TITLE
Refactor data loading helpers

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -200,3 +200,7 @@
 
 - 2025-06-16: Noted conflict-marker check in AGENTS; cleaned NOTES markers.
   Reason: prevent accidental commits with unresolved merges.
+- 2025-08-06: evaluate.load_data uses data_utils.load_data and returns
+  a DataLoader.
+  calibrate now imports from data_utils. Added test for loader output.
+  Reason: remove code duplication and keep API consistent.

--- a/TODO.md
+++ b/TODO.md
@@ -62,3 +62,7 @@
 - [x] Optional `--backend` flag in cross_validate.py to choose PyTorch or
   TensorFlow backend and tests for the TensorFlow path.
 - [x] Add baseline.py with logistic regression and tests.
+
+## 5. Maintenance
+
+- [x] Simplify evaluate.load_data using data_utils.load_data

--- a/calibrate.py
+++ b/calibrate.py
@@ -7,8 +7,9 @@ import torch
 from sklearn.calibration import CalibrationDisplay
 from sklearn.metrics import brier_score_loss
 import matplotlib.pyplot as plt
+from torch.utils.data import DataLoader, TensorDataset
 
-from evaluate import load_data
+from data_utils import load_data
 
 
 def _save_reliability_plot(
@@ -24,7 +25,10 @@ def _save_reliability_plot(
 
 def calibrate_model(model_path: Path, plot_path: Path) -> float:
     """Compute Brier score and save reliability plot."""
-    loader = load_data()
+    x_train, x_test, y_train, y_test = load_data()
+    features = torch.cat([x_train, x_test])
+    targets = torch.cat([y_train, y_test])
+    loader = DataLoader(TensorDataset(features, targets), batch_size=64)
     model = torch.load(model_path, map_location="cpu")
     model.eval()
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -3,12 +3,12 @@
 import argparse
 from pathlib import Path
 
-import pandas as pd
 import torch
 from sklearn.metrics import roc_auc_score
 from torch.utils.data import DataLoader, TensorDataset
 
 from train import train_model, _load_split
+from data_utils import load_data as _load_tensors
 
 
 def evaluate(seed: int = 0) -> float:
@@ -17,14 +17,11 @@ def evaluate(seed: int = 0) -> float:
 
 
 def load_data(batch_size: int = 64) -> DataLoader:
-    """Load the Cleveland heart dataset as a DataLoader."""
-    df = pd.read_csv(Path("data") / "heart.csv", na_values="?")
-    df = df.fillna(df.mean(numeric_only=True))
-    df = df.astype(float)
-    df["target"] = (df["target"] > 0).astype(float)
-    X = df.drop(columns=["target"]).to_numpy(dtype="float32")
-    y = df["target"].to_numpy(dtype="float32")
-    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    """Return full dataset loader via :func:`data_utils.load_data`."""
+    x_train, x_test, y_train, y_test = _load_tensors()
+    features = torch.cat([x_train, x_test])
+    targets = torch.cat([y_train, y_test])
+    dataset = TensorDataset(features, targets)
     return DataLoader(dataset, batch_size=batch_size)
 
 

--- a/tests/test_evaluate_loader.py
+++ b/tests/test_evaluate_loader.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import evaluate  # noqa: E402
+
+
+def test_load_data_returns_loader():
+    loader = evaluate.load_data(batch_size=8)
+    features, target = next(iter(loader))
+    assert isinstance(features, torch.Tensor)
+    assert isinstance(target, torch.Tensor)
+    assert features.shape[0] <= 8

--- a/train_tf.py
+++ b/train_tf.py
@@ -49,7 +49,7 @@ def train_model(
     tf.random.set_seed(seed)
     x_train, x_test, y_train, y_test = _load_split(seed)
     model = _build_model(x_train.shape[1])
-    epochs = 3 if fast else 200
+    epochs = 15 if fast else 200
     callback = tf.keras.callbacks.EarlyStopping(
         monitor="val_loss", patience=patience, restore_best_weights=True
     )


### PR DESCRIPTION
## Summary
- reuse `data_utils.load_data` inside `evaluate.load_data`
- adjust calibration helper to use tensors directly
- extend Keras fast trainer to 15 epochs so tests remain reliable
- test that `evaluate.load_data` returns a loader
- record the simplification in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685014003e5083259ae902d8797cc981