### PR TITLE
Add Cleveland dataset documentation

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -215,3 +215,6 @@
 - 2025-08-06: fast mode in `train_tf.py` now trains for 12 epochs.
   Updated cross-validate tests, README and docs to match. Reason: ensure
   quick runs hit higher ROC-AUC as requested.
+- 2025-08-07: Added docs/dataset.md describing the 13 features and target.
+Linked from README, overview and Sphinx index.
+Reason: document dataset details.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ disease.
 ## Why this repo matters
 
 * **Medical relevance in 30 kB** – uses the Cleveland subset of the classic UCI
-  Heart-Disease data (303 patients × 13 features).
+  Heart-Disease data (303 patients × 13 features). See [dataset overview](docs/dataset.md).
 * **Speed** – trains a 13-32-16-1 MLP to ≥ 0.90 test accuracy and ROC-AUC ≈
   0.93 in ~45 s on two vCPUs.
 * **Self-contained** – data file is vendored; no network needed after setup.
@@ -92,7 +92,7 @@ AGENTS.md             ← contributor & CI guidelines
 ```
 
 See [docs/overview.md](docs/overview.md) for a sketch of the MLP and
-the training workflow.
+the training workflow. Dataset columns are described in [docs/dataset.md](docs/dataset.md).
 
 ### `.env` file
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,7 @@
 - [x] Add `.markdownlint.json` ignoring `codex.md`
 - [x] Wrap long entry in NOTES.md to satisfy markdownlint
 - [x] Consolidate workflow steps in `docs/overview.md`
+- [x] Document dataset columns in docs/dataset.md and link from README.
 
 ## 4. Stretch goals
 

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,22 @@
+# Cleveland dataset
+
+The repository includes `data/heart.csv`, which is the Cleveland subset of the
+UCI Heart-Disease data. It holds 303 patient records with 13 numerical features
+and one `target` column.
+
+## Columns
+
+- `age` – age in years
+- `sex` – 1 if male, 0 if female
+- `cp` – chest pain type (0–3)
+- `trestbps` – resting blood pressure in mm Hg
+- `chol` – serum cholesterol in mg/dL
+- `fbs` – fasting blood sugar > 120 mg/dL (1 = true)
+- `restecg` – resting electrocardiographic results (0–2)
+- `thalach` – maximum heart rate achieved
+- `exang` – exercise induced angina (1 = yes)
+- `oldpeak` – ST depression induced by exercise
+- `slope` – slope of the peak exercise ST segment (0–2)
+- `ca` – number of major vessels colored by fluoroscopy (0–3)
+- `thal` – thalassemia type (1 = normal; 2 = fixed defect; 3 = reversible)
+- `target` – 1 if coronary artery disease present

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,4 +34,4 @@ inputs.
 7. Run `python baseline.py --seed 0` to train a logistic-regression
    baseline and save `baseline.pkl`.
 
-Future docs will detail the dataset and training options once implemented.
+See [dataset.md](dataset.md) for the dataset columns.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,3 +18,7 @@ CardioRisk-NN API
 
 .. automodule:: data_utils
    :members:
+
+
+.. include:: ../dataset.md
+   :literal:


### PR DESCRIPTION
## Summary
- document the Cleveland dataset in `docs/dataset.md`
- link dataset info from README and overview docs
- include the dataset page in the Sphinx build
- log the change in `NOTES.md` and mark it done in `TODO.md`

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `black .`
- `flake8`
- `pytest -q`
- `sphinx-build -b html docs/source docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_68501e10a3948325adf4554ff47425f6