### PR TITLE
Clarify evaluate_saved_model seed usage

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -229,3 +229,7 @@ Reason: document dataset details.
 - 2025-08-08: Removed stray blank line after the dataset docs entry.
   Reason: GitHub Actions failed markdownlint MD012.
   Ensure the linter is run before pushing.
+
+- 2025-08-09: Documented that `evaluate_saved_model` needs the same seed used
+  during training because the test split depends on it. Updated README and
+  overview docs accordingly. Reason: avoid misleading evaluations.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ flag so longer runs stop once the loss plateaus.
 
 `train.py` trains the MLP and saves `model.pt` when ROC‑AUC ≥ 0.90.
 `evaluate.py` loads a saved `model.pt` by default via the `--model-path`
-argument and prints ROC‑AUC. The module's `evaluate()` function (not the CLI)
-performs a short training run used in the tests.
+argument and prints ROC‑AUC. Call `evaluate_saved_model(path, seed)` with the
+same seed used for training because the test split depends on it. The module's
+`evaluate()` function (not the CLI) performs a short training run used in the
+tests.
 `calibrate.py` reports the Brier score and saves a reliability plot image for
 any saved model.
 `cross_validate.py` runs several quick training runs and accepts a

--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,8 @@
 - [x] Consolidate workflow steps in `docs/overview.md`
 - [x] Document dataset columns in docs/dataset.md and link from README.
 - [x] Document `cross_validate` and `baseline` modules in the Sphinx index
+- [x] Clarify that `evaluate_saved_model` needs the same seed used for training
+  so the test split matches.
 
 ## 4. Stretch goals
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,12 +26,16 @@ inputs.
 
 4. Models saved as `model.pt` or `model_tf.h5`; scripts exit 1 if AUC < 0.90.
 
-5. Run `python calibrate.py` to save a reliability plot and Brier score.
+5. Call `evaluate_saved_model(path, seed)` with the same seed used during
+   training. The test split depends on the seed so metrics match only when the
+   seeds align.
 
-6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
+6. Run `python calibrate.py` to save a reliability plot and Brier score.
+
+7. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
    quick k-fold score.
 
-7. Run `python baseline.py --seed 0` to train a logistic-regression
+8. Run `python baseline.py --seed 0` to train a logistic-regression
    baseline and save `baseline.pkl`.
 
 See [dataset.md](dataset.md) for the dataset columns.


### PR DESCRIPTION
## Summary
- note that evaluate_saved_model must be called with the same seed used during training
- explain this in README and docs/overview
- record the change in NOTES and tick TODO

## Testing
- `npx markdownlint-cli '**/*.md'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685136b5d28483259068c613437716f5