### PR TITLE
docs: unify markdownlint-cli instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ stay consistent.
 4. Keep edits to *distinct* source files where possible.
 5. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
 6. Search for conflict markers with `git grep '<<<<<<<'` before committing.
-7. Run `npx markdownlint-cli '**/*.md'` before pushing. The file `codex.md`
-   is excluded via `.markdownlintignore`.
+7. Run `npx --yes markdownlint-cli '**/*.md'` before pushing. The file
+   `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
 8. If you change tests, linters, or build scripts, also update **AGENTS.md**.
 9. A task is *done* only when CI is **all green**.
    Docs-only commits run only the markdown jobs; code commits run the full test suite.
@@ -40,8 +40,6 @@ stay consistent.
 * 4‑space indent, `black` line length = 88.
 * Validate inputs early; raise on bad data.
 * End every file with a newline; keep Markdown lines ≤ 80 chars.
-* Run `npx --yes markdownlint-cli '**/*.md'` (or install globally) to ensure
-  Markdown lines stay within 80 characters. This catches issues before pushing.
 * `train.py` and `train_tf.py` exit with code 1 when ROC-AUC < 0.90.
   In tests, call `train.train_model()` or `train_tf.train_model()`
   to avoid exits.
@@ -53,8 +51,6 @@ stay consistent.
 * Use fenced code blocks with language hint.
 * Surround headings/lists/code with blank lines.
 * Surround headings, lists and code with blank lines.
-* Run `npx markdownlint-cli '**/*.md'` before pushing.
-* `codex.md` is excluded via `.markdownlint.json`.
 * Keep exactly one blank line between NOTES.md entries – markdownlint (rule MD012)
   flags multiple blank lines.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -229,3 +229,6 @@ Reason: document dataset details.
 - 2025-08-08: Removed stray blank line after the dataset docs entry.
   Reason: GitHub Actions failed markdownlint MD012.
   Ensure the linter is run before pushing.
+- 2025-06-17: Consolidated markdownlint instructions in AGENTS.md to a single
+  step using `npx --yes markdownlint-cli '**/*.md'`. Reason: remove duplicate
+  guidance so contributors have one clear rule.

--- a/TODO.md
+++ b/TODO.md
@@ -73,3 +73,4 @@
   docs and tests so cross-validation stays under 40 s.
 - [x] Regression test ensures fast mode uses 12 epochs after accidental change.
 - [x] Fix MD012 blank line issue in NOTES.md.
+- [x] Consolidate `markdownlint-cli` instructions in AGENTS.md to use `--yes`.


### PR DESCRIPTION
## Summary
- keep a single markdownlint step in AGENTS.md
- record the change in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_6851369bb164832593824884839153e4