### PR TITLE
Fix loader target shape

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -229,3 +229,7 @@ Reason: document dataset details.
 - 2025-08-08: Removed stray blank line after the dataset docs entry.
   Reason: GitHub Actions failed markdownlint MD012.
   Ensure the linter is run before pushing.
+
+- 2025-08-09: Standardised loader target shape to `(batch,1)` and removed
+  extra `unsqueeze` in `train._train_epoch`. Updated calibrate loader and tests
+  accordingly. Reason: simplify loss calls and keep loaders consistent.

--- a/TODO.md
+++ b/TODO.md
@@ -73,3 +73,5 @@
   docs and tests so cross-validation stays under 40 s.
 - [x] Regression test ensures fast mode uses 12 epochs after accidental change.
 - [x] Fix MD012 blank line issue in NOTES.md.
+- [x] Standardise loader targets to `(batch,1)` and drop unsqueeze from
+  `train._train_epoch`.

--- a/calibrate.py
+++ b/calibrate.py
@@ -28,7 +28,8 @@ def calibrate_model(model_path: Path, plot_path: Path) -> float:
     x_train, x_test, y_train, y_test = load_data()
     features = torch.cat([x_train, x_test])
     targets = torch.cat([y_train, y_test])
-    loader = DataLoader(TensorDataset(features, targets), batch_size=64)
+    dataset = TensorDataset(features, targets.unsqueeze(1))
+    loader = DataLoader(dataset, batch_size=64)
     model = torch.load(model_path, map_location="cpu")
     model.eval()
 
@@ -38,7 +39,7 @@ def calibrate_model(model_path: Path, plot_path: Path) -> float:
             logits = model(features).squeeze()
             prob = torch.sigmoid(logits)
             probs.extend(prob.tolist())
-            labels.extend(target.tolist())
+            labels.extend(target.squeeze(1).tolist())
 
     brier = brier_score_loss(labels, probs)
     _save_reliability_plot(labels, probs, plot_path)

--- a/evaluate.py
+++ b/evaluate.py
@@ -21,7 +21,7 @@ def load_data(batch_size: int = 64) -> DataLoader:
     x_train, x_test, y_train, y_test = _load_tensors()
     features = torch.cat([x_train, x_test])
     targets = torch.cat([y_train, y_test])
-    dataset = TensorDataset(features, targets)
+    dataset = TensorDataset(features, targets.unsqueeze(1))
     return DataLoader(dataset, batch_size=batch_size)
 
 

--- a/tests/test_evaluate_loader.py
+++ b/tests/test_evaluate_loader.py
@@ -13,3 +13,4 @@ def test_load_data_returns_loader():
     assert isinstance(features, torch.Tensor)
     assert isinstance(target, torch.Tensor)
     assert features.shape[0] <= 8
+    assert target.shape[1] == 1

--- a/train.py
+++ b/train.py
@@ -32,7 +32,7 @@ def _train_epoch(
     for features, target in loader:
         optimizer.zero_grad()
         out = model(features)
-        loss = criterion(out, target.unsqueeze(1))
+        loss = criterion(out, target)
         loss.backward()
         optimizer.step()
 
@@ -63,7 +63,7 @@ def _split_train_valid(
     train_size = len(x_train) - val_size
     gen = torch.Generator().manual_seed(seed)
 
-    dataset = TensorDataset(x_train, y_train)
+    dataset = TensorDataset(x_train, y_train.unsqueeze(1))
     train_ds, val_ds = random_split(
         dataset,
         [train_size, val_size],


### PR DESCRIPTION
## Summary
- standardise DataLoader targets to `(batch,1)`
- remove redundant `unsqueeze` in `_train_epoch`
- adapt calibration and evaluation loaders
- assert target shape in loader test
- document the change in NOTES and TODO

## Testing
- `black --check .`
- `flake8 .`
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -q`
- `sphinx-build -b html docs/source docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_685136b2aba08325a34aa17e7c242564