### PR TITLE
Fix duplicated cross_validate step

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,7 @@ Reason: document dataset details.
 - 2025-08-09: Documented that `evaluate_saved_model` needs the same seed used
   during training because the test split depends on it. Updated README and
   overview docs accordingly. Reason: avoid misleading evaluations.
+
+- 2025-08-10: Removed duplicate cross_validate step in docs/overview and
+  renumbered the list. Reason: tidy workflow docs. Decision: kept the `--fast`
+  bullet because fast mode is default.

--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@
 - [x] Document `cross_validate` and `baseline` modules in the Sphinx index
 - [x] Clarify that `evaluate_saved_model` needs the same seed used for training
   so the test split matches.
+- [x] Remove redundant cross_validate step in docs/overview and renumber.
 
 ## 4. Stretch goals
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -35,10 +35,7 @@ inputs.
 
 7. Run `python calibrate.py` to save a reliability plot and Brier score.
 
-8. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
-   quick k-fold score.
-
-9. Run `python baseline.py --seed 0` to train a logistic-regression
+8. Run `python baseline.py --seed 0` to train a logistic-regression
    baseline and save `baseline.pkl`.
 
 See [dataset.md](dataset.md) for the dataset columns.


### PR DESCRIPTION
## Summary
- remove redundant step from `docs/overview.md`
- renumber list after the removal
- record the change in `NOTES.md`
- tick TODO item for docs cleanup

## Testing
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_68513b9d06d083259464a4eb176c0e0c