### PR TITLE
Add --no-fast flag for cross_validate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,8 @@ Reason: document dataset details.
 - 2025-08-09: Documented that `evaluate_saved_model` needs the same seed used
   during training because the test split depends on it. Updated README and
   overview docs accordingly. Reason: avoid misleading evaluations.
+
+- 2025-08-10: cross_validate CLI now uses mutually exclusive `--fast` and
+  `--no-fast` flags with fast mode on by default. Updated README, docs and added
+  regression test to verify disabling fast mode. Reason: allow slow training
+  without negating the default convenience.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ same seed used for training because the test split depends on it. The module's
 tests.
 `calibrate.py` reports the Brier score and saves a reliability plot image for
 any saved model.
-`cross_validate.py` runs several quick training runs. It accepts a `--fast`
-flag (on by default) and a `--backend {torch,tf}` option to choose which trainer
-to use. The script prints the mean ROC-AUC over the folds.
+`cross_validate.py` runs several quick training runs. Fast mode is on by
+default; add `--no-fast` to disable it. Use `--backend {torch,tf}` to choose
+which trainer to use. The script prints the mean ROC-AUC over the folds.
 
 Repository layout:
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,3 +79,5 @@
   `train._train_epoch`.
 - [x] Add `fast` flag to `cross_validate` with CLI support and update tests.
 - [x] Consolidate `markdownlint-cli` instructions in AGENTS.md to use `--yes`.
+- [x] Added `--no-fast` option to cross_validate to disable fast mode while
+  keeping the default intact (see NOTES 2025-08-10).

--- a/cross_validate.py
+++ b/cross_validate.py
@@ -8,7 +8,11 @@ import train
 import train_tf
 
 
-def cross_validate(folds: int = 5, backend: str = "torch", fast: bool = True) -> float:
+def cross_validate(
+    folds: int = 5,
+    backend: str = "torch",
+    fast: bool = True,
+) -> float:
     """Return mean ROC-AUC over several random splits.
 
     Parameters
@@ -39,9 +43,16 @@ def main(args: list[str] | None = None) -> None:
         default="torch",
         help="training backend",
     )
-    parser.add_argument("--fast", action="store_true", default=True)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--fast", dest="fast", action="store_true")
+    group.add_argument("--no-fast", dest="fast", action="store_false")
+    parser.set_defaults(fast=True)
     parsed = parser.parse_args(args)
-    mean_auc = cross_validate(parsed.folds, backend=parsed.backend, fast=parsed.fast)
+    mean_auc = cross_validate(
+        parsed.folds,
+        backend=parsed.backend,
+        fast=parsed.fast,
+    )
     print(f"Mean ROC-AUC: {mean_auc:.3f}")
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,13 +30,13 @@ inputs.
    training. The test split depends on the seed so metrics match only when the
    seeds align.
 
-6. Run `python cross_validate.py --folds 5 --fast --backend torch` (or `tf`)
-   for a quick k-fold score. Fast mode is enabled by default.
+6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
+   quick k-fold score. Add `--no-fast` to disable the default fast mode.
 
 7. Run `python calibrate.py` to save a reliability plot and Brier score.
 
 8. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
-   quick k-fold score.
+   quick k-fold score again, maybe with `--no-fast` to get the full 200 epochs.
 
 9. Run `python baseline.py --seed 0` to train a logistic-regression
    baseline and save `baseline.pkl`.

--- a/tests/test_cross_validate_no_fast.py
+++ b/tests/test_cross_validate_no_fast.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cross_validate  # noqa: E402
+
+
+def test_main_no_fast(monkeypatch):
+    called = {}
+
+    def fake_cv(folds, backend="torch", fast=True):
+        called["fast"] = fast
+        called["folds"] = folds
+        return 0.0
+
+    monkeypatch.setattr(cross_validate, "cross_validate", fake_cv)
+    cross_validate.main(["--no-fast", "--folds", "2"])
+    assert called["fast"] is False
+    assert called["folds"] == 2


### PR DESCRIPTION
## Summary
- replace `--fast` flag with `--fast/--no-fast` pair in `cross_validate.main`
- document the new option in README and docs
- regression test ensures `--no-fast` disables fast mode
- update NOTES and TODO

## Testing
- `black --check .`
- `flake8 .`
- `npx --yes markdownlint-cli '**/*.md'`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68513b909c9883259cf03e38a5ed7c8f