### PR TITLE
Fix dataset path resolution

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -245,3 +245,7 @@ Reason: document dataset details.
 - 2025-08-09: Documented that `evaluate_saved_model` needs the same seed used
   during training because the test split depends on it. Updated README and
   overview docs accordingly. Reason: avoid misleading evaluations.
+
+- 2025-08-10: load_data now uses a path relative to the module.
+  Updated README quick-start accordingly.
+  Reason: allow running scripts from any directory.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ bash setup.sh
 `setup.sh` installs **PyTorch 2.3.x** and **TensorFlow 2.x** from CPU wheels so
 runs stay GPU-free and reproducible.
 
+All helpers read `data/heart.csv` using a path relative to the module, so you
+can run scripts from any directory.
+
 Run the PyTorch training script with, for example:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -79,3 +79,4 @@
   `train._train_epoch`.
 - [x] Add `fast` flag to `cross_validate` with CLI support and update tests.
 - [x] Consolidate `markdownlint-cli` instructions in AGENTS.md to use `--yes`.
+- [x] Use module-relative path in `data_utils.load_data` and update README.

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 import torch
@@ -5,7 +7,8 @@ import torch
 
 def load_data(test_size: float = 0.2, random_state: int = 42):
     """Load heart.csv and split into train/test sets."""
-    df = pd.read_csv("data/heart.csv", na_values="?")
+    csv_path = Path(__file__).resolve().parent / "data" / "heart.csv"
+    df = pd.read_csv(csv_path, na_values="?")
     df = df.fillna(df.mean(numeric_only=True))
     df = df.astype(float)
     df["target"] = (df["target"] > 0).astype(float)


### PR DESCRIPTION
## Summary
- build data path relative to data_utils.py
- clarify dataset loading in README quick-start
- log the rationale in NOTES and mark TODO item

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_68513b9a734c8325b1e5d677983b5096