### PR TITLE
Fix docs for cross_validate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -263,3 +263,7 @@ Reason: document dataset details.
 - 2025-08-10: Removed duplicate cross_validate step in docs/overview and
   renumbered the list. Reason: tidy workflow docs. Decision: kept the `--fast`
   bullet because fast mode is default.
+
+- 2025-08-11: Deduplicated `cross_validate.py` docs in README and numbered the
+  workflow steps in `docs/overview.md`. Mentioned `--no-fast` in both places.
+  Reason: keep instructions concise and in sync with the CLI.

--- a/README.md
+++ b/README.md
@@ -72,13 +72,10 @@ same seed used for training because the test split depends on it. The module's
 tests.
 `calibrate.py` reports the Brier score and saves a reliability plot image for
 any saved model.
-`cross_validate.py` performs k‑fold cross validation with scikit‑learn's
-`KFold`. Use `--backend {torch,tf}` to pick the trainer, `--seed` for
-reproducible splits, and `--fast` (default) for a shorter run. The script prints
-the mean ROC‑AUC over the folds.
-`cross_validate.py` runs several quick training runs. Fast mode is on by
-default; add `--no-fast` to disable it. Use `--backend {torch,tf}` to choose
-which trainer to use. The script prints the mean ROC-AUC over the folds.
+`cross_validate.py` performs k-fold cross validation with scikit-learn's
+`KFold`. Use `--backend {torch,tf}` to choose the trainer, `--seed` for
+reproducible splits, and `--no-fast` to disable the default fast mode. The
+script prints the mean ROC-AUC over the folds.
 
 Repository layout:
 

--- a/TODO.md
+++ b/TODO.md
@@ -86,3 +86,4 @@
 - [x] Use module-relative path in `data_utils.load_data` and update README.
 - [x] Added `--no-fast` option to cross_validate to disable fast mode while
   keeping the default intact (see NOTES 2025-08-10).
+- [x] Deduplicated cross_validate docs and renumbered workflow steps.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,23 +30,14 @@ inputs.
    training. The test split depends on the seed so metrics match only when the
    seeds align.
 
-
-6. Run `python cross_validate.py --folds 5 --fast --backend torch` (or `tf`)
-   for a quick k-fold score. Splits come from `sklearn.model_selection.KFold`
-   and can be reproduced with `--seed 0` (default). Fast mode is enabled by
-   default.
-
-6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
-   quick k-fold score. Add `--no-fast` to disable the default fast mode.
-
+6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for
+   k-fold evaluation. Splits come from `sklearn.model_selection.KFold` and can
+   be reproduced with `--seed 0` (default). Fast mode is on by default; add
+   `--no-fast` for the full 200 epochs.
 
 7. Run `python calibrate.py` to save a reliability plot and Brier score.
 
-8. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for a
-   quick k-fold score. Pass `--seed` to repeat the same splits.
-   quick k-fold score again, maybe with `--no-fast` to get the full 200 epochs.
-
-9. Run `python baseline.py --seed 0` to train a logistic-regression
-   baseline and save `baseline.pkl`.
+8. Run `python baseline.py --seed 0` to train a logistic-regression baseline
+   and save `baseline.pkl`.
 
 See [dataset.md](dataset.md) for the dataset columns.


### PR DESCRIPTION
## Summary
- tidy cross_validate docs in README
- renumber workflow in overview and describe `--no-fast`
- record the cleanup in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_6851408c6b9c832585831dac84c80efe