### PR TITLE
Update link-check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
         run: sphinx-build -b html docs/source docs/_build
 
       - name: Check links
-        run: npx markdown-link-check README.md
+        run: npx --yes markdown-link-check README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ stay consistent.
 4. Keep edits to *distinct* source files where possible.
 5. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
 6. Search for conflict markers with `git grep '<<<<<<<'` before committing.
-7. Run `npx --yes markdownlint-cli '**/*.md'` before pushing. The file
+7. Run `npx --yes markdownlint-cli '**/*.md'` and
+   `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
 8. If you change tests, linters, or build scripts, also update **AGENTS.md**.
 9. A task is *done* only when CI is **all green**.

--- a/NOTES.md
+++ b/NOTES.md
@@ -264,11 +264,17 @@ Reason: document dataset details.
   renumbered the list. Reason: tidy workflow docs. Decision: kept the `--fast`
   bullet because fast mode is default.
 
-- 2025-08-11: Reimplemented cross_validate helpers with clearer docstrings and cleaned CLI.
-  Added tests for float return and option parsing. 
+- 2025-08-11: Reimplemented cross_validate helpers with clearer docstrings
+  and cleaned CLI. Added tests for float return and option parsing.
   Reason: finalise API after merge conflict.
 
 - 2025-08-11: Deduplicated `cross_validate.py` docs in README and numbered the
   workflow steps in `docs/overview.md`. Mentioned `--no-fast` in both places.
   Reason: keep instructions concise and in sync with the CLI.
-- 2025-08-12: Rewrote cross_validate.py to remove corrupted code. Updated CLI tests to include seed argument. Reason: previous file had syntax errors and outdated API.
+- 2025-08-12: Rewrote cross_validate.py to remove corrupted code.
+  Updated CLI tests to include seed argument.
+  Reason: previous file had syntax errors and outdated API.
+
+- 2025-08-13: Made README link check non-interactive using
+  'npx --yes markdown-link-check README.md' and updated AGENTS.
+  Reason: prevent CI prompts.

--- a/TODO.md
+++ b/TODO.md
@@ -87,3 +87,4 @@
 - [x] Added `--no-fast` option to cross_validate to disable fast mode while
   keeping the default intact (see NOTES 2025-08-10).
 - [x] Deduplicated cross_validate docs and renumbered workflow steps.
+- [x] Use non-interactive `markdown-link-check` in CI.


### PR DESCRIPTION
## Summary
- make README link check non-interactive in CI
- mention the `markdown-link-check` command in AGENTS
- record maintenance in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685146c368448325994dcbfd5b30b2b5