### PR TITLE
Fix formatting in NOTES

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -264,13 +264,13 @@ Reason: document dataset details.
   renumbered the list. Reason: tidy workflow docs. Decision: kept the `--fast`
   bullet because fast mode is default.
 
-- 2025-08-11: Reimplemented cross_validate helpers with clearer docstrings
-  and cleaned CLI. Added tests for float return and option parsing.
+- 2025-08-11: Reimplemented cross_validate helpers with clearer docstrings and
+  cleaned CLI. Added tests for float return and option parsing.
   Reason: finalise API after merge conflict.
 
-- 2025-08-11: Deduplicated `cross_validate.py` docs in README and numbered the
-  workflow steps in `docs/overview.md`. Mentioned `--no-fast` in both places.
-  Reason: keep instructions concise and in sync with the CLI.
+- 2025-08-11: Deduplicated `cross_validate.py` docs in README and numbered
+  the workflow steps in `docs/overview.md`. Mentioned `--no-fast` in both
+  places. Reason: keep instructions concise and in sync with the CLI.
 
 - 2025-08-12: Rewrote cross_validate.py to remove corrupted code.
   Updated CLI tests to include seed argument.
@@ -279,3 +279,6 @@ Reason: document dataset details.
 - 2025-08-13: Made README link check non-interactive using
   'npx --yes markdown-link-check README.md' and updated AGENTS.
   Reason: prevent CI prompts.
+
+- 2025-08-14: Wrapped NOTES entries around lines 267-276 to 80-char width and
+  checked spacing. Reason: docs style cleanup.


### PR DESCRIPTION
## Summary
- wrap documentation lines around 267–276
- ensure one blank line per entry
- log the cleanup

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685150c449708325b935736adfdc00fe