### PR TITLE
docs: clarify local linting step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ stay consistent.
 7. Run `npx --yes markdownlint-cli '**/*.md'` and
    `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
-8. If you change tests, linters, or build scripts, also update **AGENTS.md**.
-9. A task is *done* only when CI is **all green**.
+8. Run `black .`, `flake8 .` and `pytest -v` before pushing.
+9. If you change tests, linters, or build scripts, also update **AGENTS.md**.
+10. A task is *done* only when CI is **all green**.
    Docs-only commits run only the markdown jobs; code commits run the full test suite.
 
 ## 3. Coding standards

--- a/NOTES.md
+++ b/NOTES.md
@@ -286,3 +286,5 @@ Reason: document dataset details.
 
 - 2025-08-14: Wrapped NOTES entries around lines 267-276 to 80-char width and
   checked spacing. Reason: docs style cleanup.
+- 2025-08-15: Inserted workflow bullet in AGENTS to run `black .`, `flake8 .`
+  and `pytest -v` before pushing. Reason: clarify local checks.


### PR DESCRIPTION
## Summary
- document running code format and tests before pushing
- log the change in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685150c528ec8325a440d885edb51cb1