### PR TITLE
Apply black formatting

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -279,3 +279,4 @@ Reason: document dataset details.
 - 2025-08-13: Made README link check non-interactive using
   'npx --yes markdown-link-check README.md' and updated AGENTS.
   Reason: prevent CI prompts.
+\n- 2025-08-14: Ran black on cross_validate and tests. Updated tests to satisfy flake8 line length and confirmed CI checks locally. Reason: keep formatting consistent.

--- a/cross_validate.py
+++ b/cross_validate.py
@@ -101,7 +101,6 @@ def cross_validate(
     fast: bool = True,
     seed: int = 0,
 ) -> float:
-
     """Return mean ROC-AUC over a KFold split."""
 
     x, y = _load_dataset(seed)
@@ -136,8 +135,10 @@ def main(args: list[str] | None = None) -> None:
     parser.add_argument("--seed", type=int, default=0)
     parsed = parser.parse_args(args)
     mean_auc = cross_validate(
-        parsed.folds, backend=parsed.backend, fast=parsed.fast, seed=parsed.seed
-
+        parsed.folds,
+        backend=parsed.backend,
+        fast=parsed.fast,
+        seed=parsed.seed,
     )
     print(f"Mean ROC-AUC: {mean_auc:.3f}")
 

--- a/tests/test_cross_validate.py
+++ b/tests/test_cross_validate.py
@@ -1,6 +1,7 @@
 import time
 from pathlib import Path
 import sys
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cross_validate  # noqa: E402
 

--- a/tests/test_cross_validate_no_fast.py
+++ b/tests/test_cross_validate_no_fast.py
@@ -17,7 +17,15 @@ def test_main_no_fast(monkeypatch):
 
     monkeypatch.setattr(cross_validate, "cross_validate", fake_cv)
     cross_validate.main(
-        ["--no-fast", "--backend", "tf", "--folds", "2", "--seed", "5"]
+        [
+            "--no-fast",
+            "--backend",
+            "tf",
+            "--folds",
+            "2",
+            "--seed",
+            "5",
+        ]
     )
     assert called["fast"] is False
     assert called["folds"] == 2

--- a/tests/test_cross_validate_tf.py
+++ b/tests/test_cross_validate_tf.py
@@ -1,6 +1,7 @@
 import time
 from pathlib import Path
 import sys
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cross_validate  # noqa: E402
 
@@ -8,10 +9,16 @@ import cross_validate  # noqa: E402
 def test_cross_validation_tf_runs_quickly():
     start = time.time()
     auc1 = cross_validate.cross_validate(
-        folds=3, backend="tf", fast=True, seed=1
+        folds=3,
+        backend="tf",
+        fast=True,
+        seed=1,
     )
     auc2 = cross_validate.cross_validate(
-        folds=3, backend="tf", fast=True, seed=1
+        folds=3,
+        backend="tf",
+        fast=True,
+        seed=1,
     )
     assert isinstance(auc1, float)
     assert abs(auc1 - auc2) < 0.05


### PR DESCRIPTION
## Summary
- reformat `cross_validate` and related tests with black
- wrap long lines so flake8 passes
- document formatting run in `NOTES.md`

## Testing
- `flake8 .`
- `pytest -q`
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685150c321548325994198709c601a29