### PR TITLE
Fix NOTES lint errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,10 @@ stay consistent.
 * Use fenced code blocks with language hint.
 * Surround headings/lists/code with blank lines.
 * Surround headings, lists and code with blank lines.
-* Keep exactly one blank line between NOTES.md entries – markdownlint (rule MD012)
-  flags multiple blank lines.
+* Keep exactly one blank line between NOTES.md entries.
+  markdownlint (rule MD012) flags multiple blank lines.
+* Avoid trailing spaces—markdownlint (rule MD009) fails if a line ends with spaces.
+  Run `npx markdownlint-cli '**/*.md'` to check.
 
 ## 5. File roles
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -280,10 +280,9 @@ Reason: document dataset details.
   'npx --yes markdown-link-check README.md' and updated AGENTS.
   Reason: prevent CI prompts.
 
-- 2025-08-14: Ran black on cross_validate and tests. 
+- 2025-08-14: Ran black on cross_validate and tests.
   Updated tests to satisfy flake8 line length and confirmed CI checks locally.
   Reason: keep formatting consistent.
-
 
 - 2025-08-14: Fixed formatting in docs and updated AGENTS to require running
   `black`, `flake8` and tests locally before committing. Reason: ensure
@@ -293,3 +292,5 @@ Reason: document dataset details.
   checked spacing. Reason: docs style cleanup.
 - 2025-08-15: Inserted workflow bullet in AGENTS to run `black .`, `flake8 .`
   and `pytest -v` before pushing. Reason: clarify local checks.
+- 2025-08-16: Removed trailing space in NOTES entry and collapsed blank line.
+  Reason: CI failure due to markdownlint MD009/MD012.

--- a/TODO.md
+++ b/TODO.md
@@ -89,3 +89,5 @@
 - [x] Deduplicated cross_validate docs and renumbered workflow steps.
 - [x] Use non-interactive `markdown-link-check` in CI.
 - [x] Require running `black`, `flake8` and tests locally before committing.
+
+- [ ] Document trailing-space rule in AGENTS.


### PR DESCRIPTION
## Summary
- fix trailing space on notes line for black formatting entry
- clarify trailing space rule in AGENTS
- record the fix in NOTES
- add TODO item about trailing spaces

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685157ec6adc8325b644c9782067bd53