### PR TITLE
Update baseline doc behaviour

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -300,3 +300,7 @@ Reason: document dataset details.
 
 - 2025-08-17: Marked TODO about trailing spaces as completed because AGENTS
   already lists the rule. Reason: cleanup.
+
+- 2025-08-18: Documented baseline exit code behaviour and example call to
+  baseline.train_model in README and docs. Reason: clarify how to avoid the
+  SystemExit when ROC-AUC is below threshold.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ The logistic-regression baseline runs as:
 python baseline.py --seed 0
 ```
 
+Running `baseline.py` exits with status 1 when ROC-AUC is below 0.84. Use
+`baseline.train_model()` if you need the AUC without the exit:
+
+```python
+import baseline
+auc = baseline.train_model(seed=0, model_path="baseline.pkl")
+```
+
 Add `--fast` for a quick demo with early stopping. Use `--patience N` (default
 5, max 20 epochs in fast mode for `train.py`, 12 for `train_tf.py`) and
 `--model-path` to set the output file.

--- a/TODO.md
+++ b/TODO.md
@@ -92,3 +92,5 @@
 - [x] Calibrate.py uses the same preprocessing as `train.py` and tests assert
   Brier < 0.15.
 - [x] Document trailing-space rule in AGENTS.
+- [x] Document baseline exit code and `baseline.train_model()` example in README
+   and docs.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -24,7 +24,9 @@ inputs.
 3. Data split 80/20; early stopping triggers after `--patience` stale
    validation epochs (default 5).
 
-4. Models saved as `model.pt` or `model_tf.h5`; scripts exit 1 if AUC < 0.90.
+4. Models saved as `model.pt` or `model_tf.h5`; `train.py` and `train_tf.py`
+   exit with code 1 if AUC < 0.90. `baseline.py` exits with code 1 if AUC
+   < 0.84.
 
 5. Call `evaluate_saved_model(path, seed)` with the same seed used during
    training. The test split depends on the seed so metrics match only when the
@@ -40,6 +42,12 @@ inputs.
    standard deviation come from the training split.
 
 8. Run `python baseline.py --seed 0` to train a logistic-regression baseline
-   and save `baseline.pkl`.
+   and save `baseline.pkl`. In tests, call `baseline.train_model()` directly
+   to read the AUC without triggering a SystemExit:
+
+   ```python
+   import baseline
+   auc = baseline.train_model(seed=0, model_path="baseline.pkl")
+   ```
 
 See [dataset.md](dataset.md) for the dataset columns.


### PR DESCRIPTION
## Summary
- document `baseline.py` failing with exit code 1 when AUC < 0.84
- show how to call `baseline.train_model()` in scripts and tests
- log this change in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black . --check`
- `flake8 .`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68517e0b39cc8325902fb312fdac743c