### PR TITLE
Fix README CI badge path

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -309,3 +309,6 @@ Reason: document dataset details.
   state before scoring and tests check AUC doesn't drop. Reason: follow-up
   from TODO; decisions: used small helpers to stay under 20 lines per
   function.
+
+- 2025-08-19: Fixed README CI badge path to this repo. Reason: red badge because
+  placeholder path `example/CardioRisk-NN` was used.

--- a/README.md
+++ b/README.md
@@ -145,5 +145,5 @@ The HTML pages appear in `docs/_build`.
   https://www.ncbi.nlm.nih.gov/pmc/)
 
 [ci-badge]:
-  https://img.shields.io/github/actions/workflow/status/example/CardioRisk-NN/ci.yml?branch=main
-[ci-link]: https://github.com/example
+  https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/CardioRisk-NN/ci.yml?branch=main
+[ci-link]: https://github.com/IvanStarostin1984/CardioRisk-NN

--- a/TODO.md
+++ b/TODO.md
@@ -96,3 +96,4 @@
    and docs.
 - [x] Save best state dict during each validation fold and reload it before
   scoring to ensure ROC-AUC does not regress.
+- [x] Fix README CI badge path to this repo.


### PR DESCRIPTION
## Summary
- point the CI badge and link to the real repo path
- log the badge fix in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black --check .`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_685183000fec8325aa9040b2048cb381