### PR TITLE
Add reminder to update README CI badge when repo name changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ stay consistent.
 9. If you change tests, linters, or build scripts, also update **AGENTS.md**.
 10. A task is *done* only when CI is **all green**.
    Docs-only commits run only the markdown jobs; code commits run the full test suite.
+11. If you fork or rename the repo, update the CI badge links in `README.md`.
 
 ## 3. Coding standards
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -309,3 +309,5 @@ Reason: document dataset details.
   state before scoring and tests check AUC doesn't drop. Reason: follow-up
   from TODO; decisions: used small helpers to stay under 20 lines per
   function.
+- 2025-08-19: Inserted reminder in AGENTS to update README CI badge links when
+  the repo is forked or renamed. Reason: avoid stale URLs.


### PR DESCRIPTION
## Summary
- mention updating README CI badge links when forking/renaming
- log the docs update in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black .`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_685183017dac8325918eeac4a617aefd