### PR TITLE
Clarify setup before running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,13 @@ It always builds the Sphinx docs with `sphinx-build`.
 ## 2. Workflow
 
 1. Run `./setup.sh` once after cloning to install the Python deps
-   (PyTorch, TensorFlow, pandas, scikit-learn). CI installs the same
-   packages with `pip install -r requirements.txt` and then calls
-   `bash setup.sh` for parity. Keep the version pins in
-`requirements.txt` mirrored in `setup.sh` so local installs match CI.
-PyTorch and TensorFlow are pinned to minor versions (`torch==2.3.*`,
-`tensorflow==2.19.*`). Bump both files together so CI and local installs
-stay consistent.
+   (PyTorch, TensorFlow, pandas, scikit-learn). Run it before `pytest`
+   or the tests will fail. CI installs the same packages with
+   `pip install -r requirements.txt` and then calls `bash setup.sh` for
+   parity. Keep the version pins in `requirements.txt` mirrored in
+   `setup.sh` so local installs match CI. PyTorch and TensorFlow are
+   pinned to minor versions (`torch==2.3.*`, `tensorflow==2.19.*`). Bump
+   both files together so CI and local installs stay consistent.
 2. *(Optional)* build the Docker image with `docker build -t cardiorisk .`.
 3. Branch off **main** – name `feat/<topic>`.
 4. Keep edits to *distinct* source files where possible.

--- a/NOTES.md
+++ b/NOTES.md
@@ -321,3 +321,9 @@ Reason: document dataset details.
 
 - 2025-08-19: Fixed README CI badge path to this repo. Reason: red badge because
   placeholder path `example/CardioRisk-NN` was used.
+
+- 2025-08-20: Clarified in README quick-start and AGENTS workflow that
+  `bash setup.sh` must run before tests.
+  CI runs `pip install -r requirements.txt` then
+  `bash setup.sh` so local runs match.
+  Reason: avoid missing PyTorch/TensorFlow errors.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ bash setup.sh
 `setup.sh` installs **PyTorch 2.3.x** and **TensorFlow 2.x** from CPU wheels so
 runs stay GPU-free and reproducible.
 
+Run the script once before running tests:
+
+```bash
+pytest -v
+```
+
+CI first executes `pip install -r requirements.txt` and then `bash setup.sh`
+so local test runs mirror the pipeline.
+
 All helpers read `data/heart.csv` using a path relative to the module, so you
 can run scripts from any directory.
 

--- a/TODO.md
+++ b/TODO.md
@@ -97,3 +97,4 @@
 - [x] Save best state dict during each validation fold and reload it before
   scoring to ensure ROC-AUC does not regress.
 - [x] Fix README CI badge path to this repo.
+- [x] Document that running tests locally requires `bash setup.sh` first.


### PR DESCRIPTION
## Summary
- explain that `bash setup.sh` must run before tests in README Quick-start
- note the same step in AGENTS workflow section
- record the change in NOTES and tick it off in TODO

## Testing
- `black .`
- `flake8 .`
- `pytest -v`
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68518cbc5a188325a50a5ff7b6494dfc