### PR TITLE
Fix merge markers in NOTES

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -313,24 +313,16 @@ Reason: document dataset details.
 - 2025-08-19: Inserted reminder in AGENTS to update README CI badge links when
   the repo is forked or renamed. Reason: avoid stale URLs.
 
-- 2025-08-19: Inserted reminder in AGENTS to update README CI badge links when
-  the repo is forked or renamed. Reason: avoid stale URLs.
-
-- 2025-08-19: Inserted reminder in AGENTS to update README CI badge links when
-  the repo is forked or renamed. Reason: avoid stale URLs.
-
 - 2025-08-19: Fixed README CI badge path to this repo. Reason: red badge because
   placeholder path `example/CardioRisk-NN` was used.
 
-<<<<<<< codex/clarify-test-setup-in-documentation
 - 2025-08-20: Clarified in README quick-start and AGENTS workflow that
-  `bash setup.sh` must run before tests.
-  CI runs `pip install -r requirements.txt` then
-  `bash setup.sh` so local runs match.
-  Reason: avoid missing PyTorch/TensorFlow errors.
-=======
+  `bash setup.sh` must run before tests. CI runs `pip install -r requirements.txt`
+  then `bash setup.sh` so local runs match. Reason: avoid missing
+  PyTorch/TensorFlow errors.
+
 - 2025-08-20: `train.train_model` now clones the best state dict whenever
-  validation AUC improves and reloads it after early stopping. Added a
-  regression test and updated the docs. Reason: ensure the saved model is the
-  best one.
->>>>>>> main
+  validation AUC improves and reloads it after early stopping. Added a regression
+  test and updated the docs. Reason: ensure the saved model is the best one.
+
+- 2025-08-21: Removed merge markers from NOTES and deduplicated entries.


### PR DESCRIPTION
## Summary
- remove conflict markers from `NOTES.md`
- deduplicate the CI badge reminder entry
- log this cleanup for 2025-08-21

## Testing
- `npx markdownlint-cli '**/*.md'`
- `npx markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_6851909bd418832591d148ef6add4467