### PR TITLE
Docs: cleanup duplicate NOTES entry

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -332,8 +332,7 @@ Reason: document dataset details.
   then `bash setup.sh` so local runs match. Reason: avoid missing
   PyTorch/TensorFlow errors.
 
-- 2025-08-20: `train.train_model` now clones the best state dict whenever
-  validation AUC improves and reloads it after early stopping. Added a regression
-  test and updated the docs. Reason: ensure the saved model is the best one.
-
 - 2025-08-21: Removed merge markers from NOTES and deduplicated entries.
+
+- 2025-08-22: Removed duplicate bullet about cloning best state dict.
+  Reason: tidy NOTES and avoid confusion.

--- a/TODO.md
+++ b/TODO.md
@@ -101,3 +101,4 @@
 - [x] `train.train_model` restores the best validation weights before saving
   and scoring.
 - [x] Document grep for all conflict markers in AGENTS.
+- [x] Removed duplicate bullet in NOTES about cloning best state dict.


### PR DESCRIPTION
## Summary
- remove repeated `train.train_model` bullet
- document the cleanup in NOTES
- keep roadmap in sync

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685253e40b5083258d323a95932ad5db