### PR TITLE
Stabilise TensorFlow CV

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -333,13 +333,12 @@ Reason: document dataset details.
   PyTorch/TensorFlow errors.
 
 - 2025-08-21: Removed merge markers from NOTES and deduplicated entries.
-<<<<<<< codex/clean-up-markdown-and-update-notes.md
-
 - 2025-08-22: Removed duplicate bullet about cloning best state dict.
   Reason: tidy NOTES and avoid confusion.
-=======
 - 2025-08-22: Added pyproject.toml using setuptools to package the project
   and expose console scripts.
   README shows pip install usage.
   Reason: simplify installation and version management.
->>>>>>> main
+- 2025-08-23: `cross_validate._train_fold_tf` now clears the Keras session and
+  sets the random seed via `tf.keras.utils.set_random_seed` before building
+  the model. Reason: stabilise TensorFlow cross-validation tests.

--- a/TODO.md
+++ b/TODO.md
@@ -103,3 +103,5 @@
 - [x] Document grep for all conflict markers in AGENTS.
 - [x] Removed duplicate bullet in NOTES about cloning best state dict.
 - [x] Package with setuptools via pyproject.toml and expose console scripts.
+- [x] Stabilise TensorFlow cross-validation using `tf.keras.backend.clear_session()`
+  and `tf.keras.utils.set_random_seed`.

--- a/cross_validate.py
+++ b/cross_validate.py
@@ -106,6 +106,8 @@ def _train_fold_tf(
 
     np.random.seed(seed)
     tf.random.set_seed(seed)
+    tf.keras.backend.clear_session()
+    tf.keras.utils.set_random_seed(seed)
     x_tr = x_tr.numpy()
     y_tr = y_tr.numpy()
     x_va = x_va.numpy()


### PR DESCRIPTION
## Summary
- clear TF sessions before model creation in cross-validation
- set deterministic Keras seed for each fold
- log the change in NOTES
- check off roadmap item for stabilising TensorFlow CV

## Testing
- `black .`
- `flake8 .`
- `pytest -v`
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685264a890088325a4e19e8ebd0a9c42