### PR TITLE
Fix trailing spaces in NOTES.md

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -17,15 +17,15 @@
 - 2025-06-14: added Cleveland dataset and empty train.py placeholder.
   Reason: prepare for training scripts.
   Decisions: used UCI CSV and simple main guard as per TODO roadmap.
-  
+
 - 2025-07-05: Cleaned README duplication and removed stale references.
   Merged AGENTS workflow sections and kept single roadmap in TODO.
   Reason: tidy docs and reflect actual CI behaviour.
-  
+
 - 2025-07-07: Clarified README that `train.py` is a stub and removed CLI
   commands. Reason: keep docs in sync with TODO item about implementing the
   training CLI.
-  
+
 - 2025-07-09: Marked README placeholders task done in TODO.
   Reason: reflect prior docs cleanup; decisions: none.
 
@@ -324,7 +324,7 @@
   CI runs `pip install -r requirements.txt` then
   `bash setup.sh` so local runs match.
   Reason: avoid missing PyTorch/TensorFlow errors.
-  
+
 - 2025-08-20: `train.train_model` now clones the best state dict whenever
   validation AUC improves and reloads it after early stopping. Added a
   regression test and updated the docs. Reason: ensure the saved model is the
@@ -339,8 +339,6 @@
   Reason: tidy NOTES and avoid confusion.
 
 - 2025-08-21: Removed merge markers from NOTES and deduplicated entries.
-- 
-- 2025-08-22: Removed duplicate bullet about cloning best state dict.
   Reason: tidy NOTES and avoid confusion.
 
 - 2025-08-22: Added pyproject.toml using setuptools to package the project
@@ -354,3 +352,6 @@
 - 2025-08-23: `cross_validate._train_fold_tf` now clears the Keras session and
   sets the random seed via `tf.keras.utils.set_random_seed` before building
   the model. Reason: stabilise TensorFlow cross-validation tests.
+
+- 2025-08-24: Removed trailing spaces from NOTES and deleted stray bullet.
+  Reason: satisfy lint check; decisions: used sed and perl to clean.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The HTML pages appear in `docs/_build`.
 * [UCI ML Repository – Heart Disease data set](https://archive.ics.uci.edu)
 * [Kaggle mirror with cleaned CSV](https://kaggle.com)
 * [Typical logistic-regression baseline ROC-AUC ≈ 0.84-0.90](
-  https://www.ncbi.nlm.nih.gov/pmc/)
+  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4885402/)
 
 [ci-badge]:
   https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/CardioRisk-NN/ci.yml?branch=main


### PR DESCRIPTION
## Summary
- trim stray spaces in NOTES entries and remove duplicate bullet
- swap README dataset paper link to stable page

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68526d780a308325a038b36828a6a083