### PR TITLE
Update workflow docs to run git diff --check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,17 @@ It always builds the Sphinx docs with `sphinx-build`.
 6. Search for conflict markers with:
    git grep -n '<<<<<<<\|=======\|>>>>>>>'
    before committing. Leftover markers often cause markdownlint errors (e.g. MD032).
-7. Run `npx --yes markdownlint-cli '**/*.md'` and
+7. Run `git diff --check` to spot trailing whitespace before committing.
+8. Run `npx --yes markdownlint-cli '**/*.md'` and
    `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
-8. Run `black .`, `flake8 .` and `pytest -v` before pushing.
-9. If you change tests, linters, or build scripts, also update **AGENTS.md**.
-10. A task is *done* only when CI is **all green**.
-   Docs-only commits run only the markdown jobs; code commits run the full test suite.
-11. If you fork or rename the repo, update the CI badge links in `README.md`.
-12. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
+9. Run `black .`, `flake8 .` and `pytest -v` before pushing.
+10. If you change tests, linters, or build scripts, also update **AGENTS.md**.
+11. A task is *done* only when CI is **all green**.
+    Docs-only commits run only the markdown jobs;
+    code commits run the full test suite.
+12. If you fork or rename the repo, update the CI badge links in `README.md`.
+13. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
 
 ## 3. Coding standards
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -339,7 +339,6 @@
   Reason: tidy NOTES and avoid confusion.
 
 - 2025-08-21: Removed merge markers from NOTES and deduplicated entries.
-- 
 - 2025-08-22: Removed duplicate bullet about cloning best state dict.
   Reason: tidy NOTES and avoid confusion.
 
@@ -354,3 +353,7 @@
 - 2025-08-23: `cross_validate._train_fold_tf` now clears the Keras session and
   sets the random seed via `tf.keras.utils.set_random_seed` before building
   the model. Reason: stabilise TensorFlow cross-validation tests.
+
+- 2025-08-24: Documented running `git diff --check` after conflict search
+  in AGENTS. Reason: catch trailing spaces early. Decisions: renumbered later
+  steps.


### PR DESCRIPTION
## Summary
- document running `git diff --check` in the workflow
- renumber the later steps
- log the change in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68526d7a1ee48325b2d240c32f094af1