### PR TITLE
Add whitespace check instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,17 @@ It always builds the Sphinx docs with `sphinx-build`.
 6. Search for conflict markers with:
    git grep -n '<<<<<<<\|=======\|>>>>>>>'
    before committing. Leftover markers often cause markdownlint errors (e.g. MD032).
-7. Run `npx --yes markdownlint-cli '**/*.md'` and
+7. Run `git diff --check` to catch trailing whitespace before committing.
+8. Run `npx --yes markdownlint-cli '**/*.md'` and
    `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
-8. Run `black .`, `flake8 .` and `pytest -v` before pushing.
-9. If you change tests, linters, or build scripts, also update **AGENTS.md**.
-10. A task is *done* only when CI is **all green**.
-   Docs-only commits run only the markdown jobs; code commits run the full test suite.
-11. If you fork or rename the repo, update the CI badge links in `README.md`.
-12. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
+9. Run `black .`, `flake8 .` and `pytest -v` before pushing.
+10. If you change tests, linters, or build scripts, also update **AGENTS.md**.
+11. A task is *done* only when CI is **all green**.
+    Docs-only commits run only the markdown jobs;
+    code commits run the full test suite.
+12. If you fork or rename the repo, update the CI badge links in `README.md`.
+13. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
 
 ## 3. Coding standards
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -17,15 +17,15 @@
 - 2025-06-14: added Cleveland dataset and empty train.py placeholder.
   Reason: prepare for training scripts.
   Decisions: used UCI CSV and simple main guard as per TODO roadmap.
-  
+
 - 2025-07-05: Cleaned README duplication and removed stale references.
   Merged AGENTS workflow sections and kept single roadmap in TODO.
   Reason: tidy docs and reflect actual CI behaviour.
-  
+
 - 2025-07-07: Clarified README that `train.py` is a stub and removed CLI
   commands. Reason: keep docs in sync with TODO item about implementing the
   training CLI.
-  
+
 - 2025-07-09: Marked README placeholders task done in TODO.
   Reason: reflect prior docs cleanup; decisions: none.
 
@@ -324,7 +324,7 @@
   CI runs `pip install -r requirements.txt` then
   `bash setup.sh` so local runs match.
   Reason: avoid missing PyTorch/TensorFlow errors.
-  
+
 - 2025-08-20: `train.train_model` now clones the best state dict whenever
   validation AUC improves and reloads it after early stopping. Added a
   regression test and updated the docs. Reason: ensure the saved model is the
@@ -339,7 +339,6 @@
   Reason: tidy NOTES and avoid confusion.
 
 - 2025-08-21: Removed merge markers from NOTES and deduplicated entries.
-- 
 - 2025-08-22: Removed duplicate bullet about cloning best state dict.
   Reason: tidy NOTES and avoid confusion.
 
@@ -354,3 +353,5 @@
 - 2025-08-23: `cross_validate._train_fold_tf` now clears the Keras session and
   sets the random seed via `tf.keras.utils.set_random_seed` before building
   the model. Reason: stabilise TensorFlow cross-validation tests.
+- 2025-08-24: Removed trailing spaces from NOTES and added AGENTS rule to run
+  `git diff --check` before commits. Reason: enforce whitespace hygiene.

--- a/TODO.md
+++ b/TODO.md
@@ -105,3 +105,4 @@
 - [x] Package with setuptools via pyproject.toml and expose console scripts.
 - [x] Stabilise TensorFlow cross-validation using `tf.keras.backend.clear_session()`
   and `tf.keras.utils.set_random_seed`.
+- [x] Document running `git diff --check` to catch trailing whitespace.


### PR DESCRIPTION
## Summary
- mention `git diff --check` in AGENTS workflow
- check off TODO for documenting the command
- clean trailing spaces in NOTES and log the change

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68526d7b28bc832583995d6a41d9a2dd