### PR TITLE
Add logistic baseline option to cross_validate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -364,3 +364,7 @@
 
 - 2025-08-24: Removed trailing spaces from NOTES and deleted stray bullet.
   Reason: satisfy lint check; decisions: used sed and perl to clean.
+
+- 2025-08-25: cross_validate now supports a `baseline` backend using
+  logistic regression. Added test_cross_validate_baseline and updated
+  docs/README. Reason: provide reference performance via simple model.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ tests.
 `calibrate.py` uses the same preprocessing as `train.py` to report the Brier
 score and save a reliability plot image for any saved model.
 `cross_validate.py` performs k-fold cross validation with scikit-learn's
-`KFold`. Use `--backend {torch,tf}` to choose the trainer, `--seed` for
-reproducible splits, and `--no-fast` to disable the default fast mode. The
-script prints the mean ROC-AUC over the folds.
+`KFold`. Use `--backend {torch,tf,baseline}` to choose the trainer (MLP,
+  Keras or logistic regression), `--seed` for reproducible splits, and
+  `--no-fast` to disable the default fast mode. The
+  script prints the mean ROC-AUC over the folds.
 
 ### Install as a package
 

--- a/TODO.md
+++ b/TODO.md
@@ -106,3 +106,4 @@
 - [x] Stabilise TensorFlow cross-validation using `tf.keras.backend.clear_session()`
   and `tf.keras.utils.set_random_seed`.
 - [x] Document running `git diff --check` to catch trailing whitespace.
+- [x] Add baseline backend option in cross_validate with tests and docs.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -32,10 +32,11 @@ inputs.
    training. The test split depends on the seed so metrics match only when the
    seeds align.
 
-6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf`) for
-   k-fold evaluation. Splits come from `sklearn.model_selection.KFold` and can
-   be reproduced with `--seed 0` (default). Fast mode is on by default; add
-   `--no-fast` for the full 200 epochs.
+6. Run `python cross_validate.py --folds 5 --backend torch` (or `tf` or
+   `baseline`) for k-fold evaluation. Splits come from
+   `sklearn.model_selection.KFold` and can be reproduced with `--seed 0`
+   (default). Fast mode is on by default; add `--no-fast` for the full
+   200 epochs.
 
 7. Run `python calibrate.py` to save a reliability plot and Brier score.
    The script uses the same preprocessing as `train.py` so the mean and

--- a/tests/test_cross_validate_baseline.py
+++ b/tests/test_cross_validate_baseline.py
@@ -1,0 +1,26 @@
+import time
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cross_validate  # noqa: E402
+
+
+def test_cross_validation_baseline_runs_quickly():
+    start = time.time()
+    auc1 = cross_validate.cross_validate(
+        folds=3,
+        backend="baseline",
+        fast=True,
+        seed=2,
+    )
+    auc2 = cross_validate.cross_validate(
+        folds=3,
+        backend="baseline",
+        fast=True,
+        seed=2,
+    )
+    assert isinstance(auc1, float)
+    assert abs(auc1 - auc2) < 0.05
+    assert auc1 >= 0.84
+    assert time.time() - start < 20


### PR DESCRIPTION
## Summary
- extend cross_validate with `_train_fold_baseline`
- expose `backend='baseline'` for cross_validate and CLI
- document new option in README and docs/overview
- add regression test for baseline cross-validation
- update NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black . --check`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_685275b7affc8325ab78bb78bb56115c