### PR TITLE
Add prediction script to save CSVs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -364,3 +364,6 @@
 
 - 2025-08-24: Removed trailing spaces from NOTES and deleted stray bullet.
   Reason: satisfy lint check; decisions: used sed and perl to clean.
+- 2025-08-25: Added predict.py to generate CSV predictions and updated
+  README, pyproject console scripts and tests. Reason: implement new
+  helper from TODO.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ score and save a reliability plot image for any saved model.
 `KFold`. Use `--backend {torch,tf}` to choose the trainer, `--seed` for
 reproducible splits, and `--no-fast` to disable the default fast mode. The
 script prints the mean ROC-AUC over the folds.
+`predict.py` loads a saved `model.pt` and writes predicted probabilities to a
+CSV file:
+
+```bash
+python predict.py --model-path model.pt --output preds.csv --seed 0
+```
 
 ### Install as a package
 
@@ -111,6 +117,7 @@ cardiorisk-evaluate --model-path model.pt
 cardiorisk-calibrate --model-path model.pt
 cardiorisk-cross-validate --folds 5
 cardiorisk-baseline --seed 0
+cardiorisk-predict --model-path model.pt --output preds.csv
 ```
 
 Repository layout:
@@ -125,6 +132,7 @@ evaluate.py           ← model metrics helper
 calibrate.py          ← reliability plot helper
 cross_validate.py     ← k-fold validation helper
 baseline.py          ← logistic-regression baseline
+predict.py          ← save predictions to CSV
 
 README.md             ← you are here
 TODO.md               ← roadmap tasks

--- a/TODO.md
+++ b/TODO.md
@@ -106,3 +106,4 @@
 - [x] Stabilise TensorFlow cross-validation using `tf.keras.backend.clear_session()`
   and `tf.keras.utils.set_random_seed`.
 - [x] Document running `git diff --check` to catch trailing whitespace.
+- [x] Add predict.py with CSV output, tests and docs.

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,47 @@
+"""Generate predictions from a saved model."""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from train import _load_split
+
+
+def predict_saved_model(
+    model_path: Path,
+    output_path: Path,
+    seed: int = 0,
+) -> None:
+    """Save model probabilities for the full dataset to ``output_path``."""
+    x_train, x_test, _, _ = _load_split(seed)
+    features = torch.cat([x_train, x_test])
+    dataset = TensorDataset(features)
+    loader = DataLoader(dataset, batch_size=64, shuffle=False)
+    model = torch.load(model_path, map_location="cpu")
+    model.eval()
+
+    preds = []
+    with torch.no_grad():
+        for (batch,) in loader:
+            logits = model(batch).squeeze()
+            preds.append(torch.sigmoid(logits))
+
+    df = pd.DataFrame({"prediction": torch.cat(preds).numpy()})
+    df.to_csv(output_path, index=False)
+    print(f"Saved predictions to {output_path}")
+
+
+def main(args=None) -> None:
+    parser = argparse.ArgumentParser(description="Generate CSV predictions")
+    parser.add_argument("--model-path", default="model.pt", type=Path)
+    parser.add_argument("--output", default="predictions.csv", type=Path)
+    parser.add_argument("--seed", type=int, default=0)
+    parsed = parser.parse_args(args)
+    predict_saved_model(parsed.model_path, parsed.output, seed=parsed.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cardiorisk-nn"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
     "torch==2.3.*",
@@ -22,3 +22,4 @@ cardiorisk-evaluate = "evaluate:main"
 cardiorisk-calibrate = "calibrate:main"
 cardiorisk-cross-validate = "cross_validate:main"
 cardiorisk-baseline = "baseline:main"
+cardiorisk-predict = "predict:main"

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import train  # noqa: E402
+import predict  # noqa: E402
+
+
+def test_predict_creates_csv(tmp_path):
+    model_path = tmp_path / "model.pt"
+    out_csv = tmp_path / "preds.csv"
+    train.train_model(True, seed=0, model_path=str(model_path))
+    predict.predict_saved_model(model_path, out_csv, seed=0)
+    assert out_csv.exists()
+    df = pd.read_csv(out_csv)
+    assert df.shape == (303, 1)
+
+    args = [
+        "--model-path",
+        str(model_path),
+        "--output",
+        str(out_csv),
+        "--seed",
+        "0",
+    ]
+    predict.main(args)
+    assert out_csv.exists()


### PR DESCRIPTION
## Summary
- support CSV predictions via predict.py and CLI
- test that predictions are saved with correct shape
- document new helper in README and expose cardiorisk-predict console entry
- bump package version to 0.1.1
- log the change in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black .`
- `flake8 .`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_685275b9787883258cc392135b642e85