### PR TITLE
Format cross_validate.py with black

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -372,3 +372,5 @@
 - 2025-08-25: cross_validate now supports a `baseline` backend using
   logistic regression. Added test_cross_validate_baseline and updated
   docs/README. Reason: provide reference performance via simple model.
+
+- 2025-08-26: formatted cross_validate.py with black to fix CI failure.

--- a/cross_validate.py
+++ b/cross_validate.py
@@ -180,17 +180,18 @@ def cross_validate(
         if backend == "torch":
             auc = _train_fold_torch(x[tr], y[tr], x[va], y[va], fast, seed + i)
         elif backend == "tf":
-            auc = _train_fold_tf(
-                x[tr], y[tr], x[va], y[va], fast, seed + i
-            )
+            auc = _train_fold_tf(x[tr], y[tr], x[va], y[va], fast, seed + i)
         elif backend == "baseline":
             auc = _train_fold_baseline(
-                x[tr], y[tr], x[va], y[va], fast, seed + i
+                x[tr],
+                y[tr],
+                x[va],
+                y[va],
+                fast,
+                seed + i,
             )
         else:
-            raise ValueError(
-                "backend must be 'torch', 'tf' or 'baseline'"
-            )
+            raise ValueError("backend must be 'torch', 'tf' or 'baseline'")
 
         aucs.append(auc)
     return float(sum(aucs) / len(aucs))


### PR DESCRIPTION
## Summary
- format cross_validate.py with black
- note formatting fix in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black .`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_68527c174a74832595fa5b7819f1abd1