### PR TITLE
Update AGENTS workflow on black check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ It always builds the Sphinx docs with `sphinx-build`.
 8. Run `npx --yes markdownlint-cli '**/*.md'` and
    `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
-9. Run `black .`, `flake8 .` and `pytest -v` before pushing.
+9. Run `black --check .` before pushing.
+   If it reports issues, run `black .` to format.
+   Then re-run `black --check .`, `flake8 .` and `pytest -v`.
 10. If you change tests, linters, or build scripts, also update **AGENTS.md**.
 11. A task is *done* only when CI is **all green**.
     Docs-only commits run only the markdown jobs;

--- a/NOTES.md
+++ b/NOTES.md
@@ -372,3 +372,6 @@
 - 2025-08-25: cross_validate now supports a `baseline` backend using
   logistic regression. Added test_cross_validate_baseline and updated
   docs/README. Reason: provide reference performance via simple model.
+
+- 2025-08-26: Added rule in AGENTS to run 'black --check .' and fix issues
+  with 'black .' before pushing. Reason: clarify formatting step.

--- a/TODO.md
+++ b/TODO.md
@@ -108,3 +108,5 @@
 - [x] Document running `git diff --check` to catch trailing whitespace.
 - [x] Add predict.py with CSV output, tests and docs.
 - [x] Add baseline backend option in cross_validate with tests and docs.
+- [x] Document running `black --check .` before pushing
+  and fixing issues with `black .`


### PR DESCRIPTION
## Summary
- clarify running `black --check .` before pushing
- note the change in the project history
- tick TODO about documenting the black check

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68527c189c3883258928b315e0a85e62