### PR TITLE
Docs: clean up cross_validate section

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -380,3 +380,6 @@
 
 - 2025-08-27: Cleaned up leftover merge markers in NOTES to pass markdownlint.
   Reason: CI failed with MD032.
+
+- 2025-06-18: Deduplicated cross_validate bullet in README and listed all
+  backends (torch, tf, baseline). Reason: cleanup docs.

--- a/README.md
+++ b/README.md
@@ -90,21 +90,16 @@ same seed used for training because the test split depends on it. The module's
 tests.
 `calibrate.py` uses the same preprocessing as `train.py` to report the Brier
 score and save a reliability plot image for any saved model.
-`cross_validate.py` performs k-fold cross validation with scikit-learn's
-`KFold`. Use `--backend {torch,tf}` to choose the trainer, `--seed` for
-reproducible splits, and `--no-fast` to disable the default fast mode. The
-script prints the mean ROC-AUC over the folds.
+`cross_validate.py` runs k-fold validation.
+Use `--backend {torch,tf,baseline}` to pick a trainer,
+`--seed` for reproducible splits and `--no-fast` to disable fast mode.
+The script outputs the mean ROC-AUC.
 `predict.py` loads a saved `model.pt` and writes predicted probabilities to a
 CSV file:
 
 ```bash
 python predict.py --model-path model.pt --output preds.csv --seed 0
 ```
-
-`KFold`. Use `--backend {torch,tf,baseline}` to choose the trainer (MLP,
-  Keras or logistic regression), `--seed` for reproducible splits, and
-  `--no-fast` to disable the default fast mode. The
-  script prints the mean ROC-AUC over the folds.
 
 ### Install as a package
 


### PR DESCRIPTION
## Summary
- streamline the README description of `cross_validate.py`
- mention all backends in one bullet
- log the cleanup in `NOTES.md`

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_6852995a74b883259d31270546a76a68