### PR TITLE
docs: clarify MD032 rule in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ It always builds the Sphinx docs with `sphinx-build`.
   markdownlint (rule MD012) flags multiple blank lines.
 * Avoid trailing spaces—markdownlint (rule MD009) fails if a line ends with spaces.
   Run `npx markdownlint-cli '**/*.md'` to check.
+* Follow every list with a blank line—even after the last item—so
+  markdownlint rule MD032 passes.
 
 ## 5. File roles
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -390,3 +390,6 @@
 
 - 2025-06-18: Deduplicated cross_validate bullet in README and listed all
   backends (torch, tf, baseline). Reason: cleanup docs.
+
+- 2025-08-29: Clarified MD032 blank line rule in AGENTS.
+  Reason: prevent list-related markdownlint failures.


### PR DESCRIPTION
## Summary
- explain that lists need a blank line after the final item
- log the change in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black --check .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6852a1981b6c8325ace9affca0c2c235