### PR TITLE
Document TYPE_CHECKING imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ It always builds the Sphinx docs with `sphinx-build`.
   to avoid exits.
 * `baseline.py` exits with code 1 when ROC-AUC < 0.84.
   Call `baseline.train_model()` in tests to avoid the exit.
+* Import heavy packages used only for type hints inside `if TYPE_CHECKING:`
+  blocks. This avoids flake8 F821 and keeps runtime imports light. Run
+  `flake8 .` after updating such hints.
 
 ## 4. Documentation style
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -397,3 +397,7 @@
 
 - 2025-08-29: Clarified MD032 blank line rule in AGENTS.
   Reason: prevent list-related markdownlint failures.
+- 2025-08-30: Documented importing heavy dependencies for type hints under
+  if TYPE_CHECKING in AGENTS. Reason: avoid flake8 F821 while keeping
+  imports lightweight.
+

--- a/TODO.md
+++ b/TODO.md
@@ -116,3 +116,4 @@
 
 - [x] Include data/heart.csv in wheel so load_data works after `pip install .`.
 - [x] Fixed MD032 by adding trailing blank line in NOTES.
+- [x] Document using `if TYPE_CHECKING:` for heavy type hints in AGENTS.


### PR DESCRIPTION
## Summary
- mention importing heavy type-hint deps inside `if TYPE_CHECKING:` blocks
- log the decision in NOTES and tick TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_6852a7277fd883259468e22da24d2a4b