### PR TITLE
Add configurable early-stopping patience for cross-validate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -405,3 +405,7 @@
 - 2025-08-30: Documented importing heavy dependencies for type hints under
   if TYPE_CHECKING in AGENTS. Reason: avoid flake8 F821 while keeping
   imports lightweight.
+
+- 2025-08-31: cross_validate.py exposes a `--patience` flag and parameter,
+  passing it to both the PyTorch and TensorFlow loops. Reason: unify
+  early-stopping configuration with the training scripts.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ score and save a reliability plot image for any saved model.
 `cross_validate.py` runs k-fold validation.
 Use `--backend {torch,tf,baseline}` to pick a trainer,
 `--seed` for reproducible splits and `--no-fast` to disable fast mode.
+Add `--patience N` to change early stopping patience (default 5).
 The script outputs the mean ROC-AUC.
 `predict.py` loads a saved `model.pt` and writes predicted probabilities to a
 CSV file:

--- a/TODO.md
+++ b/TODO.md
@@ -119,3 +119,5 @@
 - [x] Guarded TensorFlow imports using TYPE_CHECKING and wrapped long
   return lines in cross_validate helper.
 - [x] Document using `if TYPE_CHECKING:` for heavy type hints in AGENTS.
+- [x] Expose `--patience` flag in cross_validate and pass through to early
+  stopping.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ inputs.
    `baseline`) for k-fold evaluation. Splits come from
    `sklearn.model_selection.KFold` and can be reproduced with `--seed 0`
    (default). Fast mode is on by default; add `--no-fast` for the full
-   200 epochs.
+   200 epochs. Set `--patience N` to control early stopping (default 5).
 
 7. Run `python calibrate.py` to save a reliability plot and Brier score.
    The script uses the same preprocessing as `train.py` so the mean and

--- a/tests/test_cross_validate.py
+++ b/tests/test_cross_validate.py
@@ -61,5 +61,18 @@ def test_auc_not_lower_than_old_impl():
         y[va],
         True,
         0,
+        5,
     )
     assert auc_new >= auc_old - 1e-4
+
+
+def test_main_patience(monkeypatch):
+    called = {}
+
+    def fake_cv(folds, backend="torch", fast=True, seed=0, patience=5):
+        called["patience"] = patience
+        return 0.0
+
+    monkeypatch.setattr(cross_validate, "cross_validate", fake_cv)
+    cross_validate.main(["--patience", "3"])
+    assert called["patience"] == 3

--- a/tests/test_cross_validate_baseline.py
+++ b/tests/test_cross_validate_baseline.py
@@ -24,3 +24,17 @@ def test_cross_validation_baseline_runs_quickly():
     assert abs(auc1 - auc2) < 0.05
     assert auc1 >= 0.84
     assert time.time() - start < 20
+
+
+def test_cli_patience_baseline(monkeypatch):
+    called = {}
+
+    def fake_cv(folds, backend="torch", fast=True, seed=0, patience=5):
+        called["backend"] = backend
+        called["patience"] = patience
+        return 0.0
+
+    monkeypatch.setattr(cross_validate, "cross_validate", fake_cv)
+    cross_validate.main(["--backend", "baseline", "--patience", "6"])
+    assert called["backend"] == "baseline"
+    assert called["patience"] == 6

--- a/tests/test_cross_validate_no_fast.py
+++ b/tests/test_cross_validate_no_fast.py
@@ -8,10 +8,9 @@ import cross_validate  # noqa: E402
 def test_main_no_fast(monkeypatch):
     called = {}
 
-    def fake_cv(folds, backend="torch", fast=True, seed=0):
+    def fake_cv(folds, backend="torch", fast=True, seed=0, patience=5):
         called["fast"] = fast
         called["folds"] = folds
-
         called["seed"] = seed
         return 0.0
 

--- a/tests/test_cross_validate_tf.py
+++ b/tests/test_cross_validate_tf.py
@@ -24,3 +24,17 @@ def test_cross_validation_tf_runs_quickly():
     assert abs(auc1 - auc2) < 0.05
     assert auc1 >= 0.80
     assert time.time() - start < 40
+
+
+def test_cli_patience_tf(monkeypatch):
+    called = {}
+
+    def fake_cv(folds, backend="torch", fast=True, seed=0, patience=5):
+        called["patience"] = patience
+        called["backend"] = backend
+        return 0.0
+
+    monkeypatch.setattr(cross_validate, "cross_validate", fake_cv)
+    cross_validate.main(["--backend", "tf", "--patience", "4"])
+    assert called["backend"] == "tf"
+    assert called["patience"] == 4


### PR DESCRIPTION
## Summary
- allow passing patience to `_run_epochs` and `_fit_tf_model`
- expose `patience` in `cross_validate.cross_validate` and CLI
- document the new flag in README and docs
- log change in NOTES and roadmap
- test CLI parsing for patience across backends

## Testing
- `black --check .`
- `flake8 .`
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b2e85f8483258b0879114759ebd8