### PR TITLE
Update contributor guide with dev tool install tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,27 +23,30 @@ It always builds the Sphinx docs with `sphinx-build`.
    `setup.sh` so local installs match CI. PyTorch and TensorFlow are
    pinned to minor versions (`torch==2.3.*`, `tensorflow==2.19.*`). Bump
    both files together so CI and local installs stay consistent.
-2. *(Optional)* build the Docker image with `docker build -t cardiorisk .`.
-3. Branch off **main** – name `feat/<topic>`.
-4. Keep edits to *distinct* source files where possible.
-5. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
-6. Search for conflict markers with:
+2. Install the dev tools with `pip install black flake8 pytest sphinx`
+   after running `setup.sh`. This keeps your local checks consistent
+   with CI.
+3. *(Optional)* build the Docker image with `docker build -t cardiorisk .`.
+4. Branch off **main** – name `feat/<topic>`.
+5. Keep edits to *distinct* source files where possible.
+6. Update **NOTES.md** (dated bullet) and **TODO.md** (tick or add task).
+7. Search for conflict markers with:
    git grep -n '<<<<<<<\|=======\|>>>>>>>'
    before committing. Leftover markers often cause markdownlint errors (e.g. MD032).
-7. Run `git diff --check` to catch trailing whitespace before committing.
+8. Run `git diff --check` to catch trailing whitespace before committing.
 
-8. Run `npx --yes markdownlint-cli '**/*.md'` and
+9. Run `npx --yes markdownlint-cli '**/*.md'` and
    `npx --yes markdown-link-check README.md` before pushing. The file
    `codex.md` is excluded via `.markdownlintignore` and `.markdownlint.json`.
-9. Run `black --check .` before pushing.
+10. Run `black --check .` before pushing.
    If it reports issues, run `black .` to format.
    Then re-run `black --check .`, `flake8 .` and `pytest -v`.
-10. If you change tests, linters, or build scripts, also update **AGENTS.md**.
-11. A task is *done* only when CI is **all green**.
+11. If you change tests, linters, or build scripts, also update **AGENTS.md**.
+12. A task is *done* only when CI is **all green**.
     Docs-only commits run only the markdown jobs;
     code commits run the full test suite.
-12. If you fork or rename the repo, update the CI badge links in `README.md`.
-13. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
+13. If you fork or rename the repo, update the CI badge links in `README.md`.
+14. Bump the version in `pyproject.toml` whenever packaging or console scripts change.
 
 ## 3. Coding standards
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -418,3 +418,6 @@
 - 2025-09-01: Added description, readme, license and author fields to pyproject,
   bumped version to 0.1.3 and updated README install example.
   Reason: finalise package metadata for release.
+- 2025-09-02: Documented installing dev tools via
+  'pip install black flake8 pytest sphinx' after setup.sh in AGENTS.
+  Reason: keep local checks consistent with CI.

--- a/TODO.md
+++ b/TODO.md
@@ -126,4 +126,6 @@
 
 - [x] Add F1 score computation in `evaluate_saved_model` and update tests and
   docs.
+- [x] Document installing dev tools
+  with `pip install black flake8 pytest sphinx` after setup.sh in AGENTS.
 - [ ] Release version 0.1.3 to PyPI

--- a/evaluate.py
+++ b/evaluate.py
@@ -25,9 +25,7 @@ def load_data(batch_size: int = 64) -> DataLoader:
     return DataLoader(dataset, batch_size=batch_size)
 
 
-def evaluate_saved_model(
-    model_path: Path, seed: int = 0
-) -> tuple[float, float]:
+def evaluate_saved_model(model_path: Path, seed: int = 0) -> tuple[float, float]:
     """Load a saved model and print ROC-AUC and F1."""
     _, x_test, _, y_test = _load_split(seed)
     model = torch.load(model_path, map_location="cpu")


### PR DESCRIPTION
## Summary
- require installing dev tools after running `setup.sh`
- log new step in NOTES and roadmap
- run black on evaluate.py

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `npx --yes markdown-link-check README.md`
- `black --check .`
- `flake8 .`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_6852bb846a688325a22e215bcd459dbb