### PR TITLE
Fix evaluate formatting

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -425,3 +425,6 @@
 
 - 2025-09-02: Reformatted evaluate.py with black after CI failed on line length.
   Confirmed flake8 and all tests pass.
+
+- 2025-06-18: Reformatted evaluate.py with black and verified flake8 and tests pass. Reason: keep formatting consistent.
+

--- a/evaluate.py
+++ b/evaluate.py
@@ -15,6 +15,7 @@ def evaluate(seed: int = 0) -> float:
     """Run a short training to compute ROC-AUC."""
     return train_model(fast=True, seed=seed, model_path=None)
 
+
 def load_data(batch_size: int = 64) -> DataLoader:
     """Return full dataset loader via :func:`data_utils.load_data`."""
     x_train, x_test, y_train, y_test = _load_tensors()
@@ -23,8 +24,11 @@ def load_data(batch_size: int = 64) -> DataLoader:
     dataset = TensorDataset(features, targets.unsqueeze(1))
     return DataLoader(dataset, batch_size=batch_size)
 
-def evaluate_saved_model(model_path: Path, seed: int = 0) -> tuple[float, float]:
 
+def evaluate_saved_model(
+    model_path: Path,
+    seed: int = 0,
+) -> tuple[float, float]:
     """Load a saved model and print ROC-AUC and F1."""
     _, x_test, _, y_test = _load_split(seed)
     model = torch.load(model_path, map_location="cpu")


### PR DESCRIPTION
## Summary
- run `black evaluate.py`
- keep line length under 79 characters so flake8 passes
- document the update in NOTES

## Testing
- `flake8 .`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6852e97e345c8325b17efd20a234d749